### PR TITLE
Add Obsidian markdown section

### DIFF
--- a/assets/obsidian-markdown.css
+++ b/assets/obsidian-markdown.css
@@ -1,0 +1,123 @@
+/* Obsidian-inspired markdown styling */
+.obsidian-markdown--enabled {
+  --obsidian-bg: #1e1e2a;
+  --obsidian-surface: #2a2a3c;
+  --obsidian-border: #3b3b52;
+  --obsidian-accent: #7f9cf5;
+  --obsidian-text: #e4e8f0;
+  --obsidian-muted: #a0a8c3;
+  color: var(--obsidian-text);
+}
+
+.obsidian-markdown--enabled a {
+  color: var(--obsidian-accent);
+  text-decoration: none;
+}
+
+.obsidian-markdown--enabled a:hover {
+  text-decoration: underline;
+}
+
+.obsidian-markdown--enabled p,
+.obsidian-markdown--enabled ul,
+.obsidian-markdown--enabled ol {
+  margin: 0 0 1.2em;
+  line-height: 1.7;
+  color: var(--obsidian-text);
+}
+
+.obsidian-markdown--enabled h1,
+.obsidian-markdown--enabled h2,
+.obsidian-markdown--enabled h3,
+.obsidian-markdown--enabled h4,
+.obsidian-markdown--enabled h5,
+.obsidian-markdown--enabled h6 {
+  color: var(--obsidian-text);
+  margin: 1.2em 0 0.5em;
+  line-height: 1.25;
+  font-weight: 700;
+}
+
+.obsidian-markdown--enabled h1 { font-size: 2.25rem; }
+.obsidian-markdown--enabled h2 { font-size: 1.9rem; }
+.obsidian-markdown--enabled h3 { font-size: 1.6rem; }
+.obsidian-markdown--enabled h4 { font-size: 1.35rem; }
+.obsidian-markdown--enabled h5 { font-size: 1.1rem; }
+.obsidian-markdown--enabled h6 { font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.05em; }
+
+.obsidian-markdown--enabled blockquote {
+  margin: 0 0 1.4em;
+  padding: 0.8em 1.2em;
+  border-left: 3px solid var(--obsidian-accent);
+  background: var(--obsidian-surface);
+  color: var(--obsidian-muted);
+  font-style: italic;
+}
+
+.obsidian-markdown--enabled code {
+  background: var(--obsidian-surface);
+  color: var(--obsidian-accent);
+  padding: 0.1em 0.3em;
+  border-radius: 6px;
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.95em;
+}
+
+.obsidian-markdown--enabled pre {
+  background: var(--obsidian-surface);
+  color: var(--obsidian-text);
+  border: 1px solid var(--obsidian-border);
+  border-radius: 12px;
+  padding: 1em;
+  overflow: auto;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.obsidian-markdown--enabled pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.obsidian-markdown--enabled hr {
+  border: 0;
+  border-top: 1px solid var(--obsidian-border);
+  margin: 2em 0;
+}
+
+.obsidian-markdown--enabled ul,
+.obsidian-markdown--enabled ol {
+  padding-left: 1.3em;
+}
+
+.obsidian-markdown--enabled ul li::marker,
+.obsidian-markdown--enabled ol li::marker {
+  color: var(--obsidian-accent);
+}
+
+.obsidian-markdown--enabled table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1.2em 0;
+  color: var(--obsidian-text);
+}
+
+.obsidian-markdown--enabled table th,
+.obsidian-markdown--enabled table td {
+  border: 1px solid var(--obsidian-border);
+  padding: 0.75em;
+  background: rgba(42, 42, 60, 0.5);
+}
+
+.obsidian-markdown--enabled table th {
+  text-align: left;
+  background: rgba(42, 42, 60, 0.8);
+}
+
+.obsidian-markdown--enabled .task-list-item {
+  list-style: none;
+}
+
+.obsidian-markdown--enabled .task-list-item input[type="checkbox"] {
+  margin-right: 0.5em;
+}

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -3405,6 +3405,22 @@
       "presets": {
         "name": "Collapsible content"
       }
+    },
+    "obsidian_markdown": {
+      "name": "Obsidian markdown",
+      "settings": {
+        "markdown_content": {
+          "label": "Markdown content",
+          "default": "## Obsidian note\nCapture ideas with **Markdown** headings, lists, and code fences.\n\n- Bullet lists\n- [Links](https://example.com)\n\n```javascript\nconsole.log('Hello, Obsidian');\n```"
+        },
+        "enable_obsidian_style": {
+          "label": "Enable Obsidian styling",
+          "info": "Toggle Obsidian-inspired typography, code blocks, and blockquotes."
+        }
+      },
+      "presets": {
+        "name": "Obsidian markdown"
+      }
     }
   }
 }

--- a/sections/obsidian-markdown.liquid
+++ b/sections/obsidian-markdown.liquid
@@ -12,14 +12,20 @@
   }
 {%- endstyle -%}
 
-<div class="color-{{ section.settings.color_scheme }} gradient">
-  <div class="page-width section-{{ section.id }}-padding">
-    {% render 'obsidian-markdown-renderer',
-      markdown_content: section.settings.markdown_content,
-      enable_obsidian_style: section.settings.enable_obsidian_style
-    %}
+{%- liquid
+  assign markdown_content = section.settings.markdown_content | to_string | strip
+-%}
+
+{%- if markdown_content != blank -%}
+  <div class="isolate color-{{ section.settings.color_scheme }} gradient">
+    <div class="page-width section-{{ section.id }}-padding" {{ section.shopify_attributes }}>
+      {% render 'obsidian-markdown-renderer',
+        markdown_content: markdown_content,
+        enable_obsidian_style: section.settings.enable_obsidian_style
+      %}
+    </div>
   </div>
-</div>
+{%- endif -%}
 
 {% schema %}
 {

--- a/sections/obsidian-markdown.liquid
+++ b/sections/obsidian-markdown.liquid
@@ -1,0 +1,79 @@
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+{%- endstyle -%}
+
+<div class="color-{{ section.settings.color_scheme }} gradient">
+  <div class="page-width section-{{ section.id }}-padding">
+    {% render 'obsidian-markdown-renderer',
+      markdown_content: section.settings.markdown_content,
+      enable_obsidian_style: section.settings.enable_obsidian_style
+    %}
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "t:sections.obsidian_markdown.name",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "textarea",
+      "id": "markdown_content",
+      "label": "t:sections.obsidian_markdown.settings.markdown_content.label",
+      "default": "t:sections.obsidian_markdown.settings.markdown_content.default"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_obsidian_style",
+      "label": "t:sections.obsidian_markdown.settings.enable_obsidian_style.label",
+      "default": true
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "t:sections.all.colors.label",
+      "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 36
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:sections.obsidian_markdown.presets.name"
+    }
+  ]
+}
+{% endschema %}

--- a/snippets/obsidian-markdown-renderer.liquid
+++ b/snippets/obsidian-markdown-renderer.liquid
@@ -1,0 +1,18 @@
+{%- comment -%}
+  Renders markdown content using Shopify's markdown filter and optionally applies
+  Obsidian-inspired styling.
+{%- endcomment -%}
+{%- liquid
+  assign content = markdown_content | to_string | strip
+  assign enable_styles = enable_obsidian_style | default: false
+-%}
+
+{%- if content != blank -%}
+  {%- if enable_styles -%}
+    {{ 'obsidian-markdown.css' | asset_url | stylesheet_tag }}
+  {%- endif -%}
+
+  <div class="obsidian-markdown{% if enable_styles %} obsidian-markdown--enabled{% endif %}">
+    {{ content | markdownify }}
+  </div>
+{%- endif -%}

--- a/snippets/obsidian-markdown-renderer.liquid
+++ b/snippets/obsidian-markdown-renderer.liquid
@@ -12,7 +12,7 @@
     {{ 'obsidian-markdown.css' | asset_url | stylesheet_tag }}
   {%- endif -%}
 
-  <div class="obsidian-markdown{% if enable_styles %} obsidian-markdown--enabled{% endif %}">
+  <div class="obsidian-markdown rte{% if enable_styles %} obsidian-markdown--enabled{% endif %}">
     {{ content | markdownify }}
   </div>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- add a reusable Obsidian markdown renderer snippet and new section for markdown content
- include Obsidian-inspired typography and code styling asset gated by a section toggle
- localize the new section labels and preset entry for easy insertion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252873793c83289d8d50d2dfa9b72e)