### PR TITLE
Add Obsidian styling for multirow section

### DIFF
--- a/assets/multirow-obsidian.css
+++ b/assets/multirow-obsidian.css
@@ -1,0 +1,171 @@
+.multirow--obsidian {
+  --multirow-bg: #0f1115;
+  --multirow-card: #141820;
+  --multirow-card-border: #1e2530;
+  --multirow-text: #c6cbd4;
+  --multirow-muted: #8d96a3;
+  --multirow-accent: #5aa9e6;
+  --multirow-accent-strong: #7ac7ff;
+  --multirow-radius: 16px;
+  --multirow-gap: clamp(16px, 3vw, 28px);
+  --multirow-shadow: 0 18px 40px rgba(6, 10, 14, 0.45);
+}
+
+.multirow--obsidian .multirow__inner {
+  display: grid;
+  gap: var(--multirow-gap);
+  padding-inline: clamp(10px, 3vw, 22px);
+}
+
+.multirow--obsidian .multirow__block {
+  position: relative;
+  isolation: isolate;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+  border: 1px solid var(--multirow-card-border);
+  border-radius: var(--multirow-radius);
+  box-shadow: var(--multirow-shadow);
+  overflow: hidden;
+  color: var(--multirow-text);
+  transition: transform 150ms ease, border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.multirow--obsidian .multirow__block:hover {
+  transform: translateY(-2px);
+  border-color: rgba(122, 199, 255, 0.45);
+  box-shadow: 0 20px 48px rgba(10, 16, 24, 0.6);
+}
+
+.multirow--obsidian .multirow__grid {
+  gap: var(--multirow-gap);
+  align-items: stretch;
+}
+
+.multirow--obsidian .multirow__media .image-with-text__media {
+  border-radius: var(--multirow-radius) 0 0 var(--multirow-radius);
+  border: 1px solid var(--multirow-card-border);
+  background: #0b0d11;
+  overflow: hidden;
+  height: 100%;
+}
+
+@media screen and (max-width: 749px) {
+  .multirow--obsidian .multirow__media .image-with-text__media {
+    border-radius: var(--multirow-radius) var(--multirow-radius) 0 0;
+  }
+}
+
+.multirow--obsidian .multirow__content {
+  display: flex;
+  align-items: stretch;
+}
+
+.multirow--obsidian .multirow__content-inner {
+  position: relative;
+  background: var(--multirow-card);
+  border-radius: var(--multirow-radius);
+  border: 1px solid var(--multirow-card-border);
+  color: var(--multirow-text);
+  padding: clamp(20px, 2vw, 28px);
+  display: grid;
+  gap: 10px;
+}
+
+.multirow--obsidian .image-with-text__heading {
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  color: #e8ecf2;
+  letter-spacing: -0.01em;
+}
+
+.multirow--obsidian .image-with-text__text {
+  color: var(--multirow-muted);
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.multirow--obsidian .image-with-text__text--caption {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
+  color: var(--multirow-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.78rem;
+}
+
+.multirow--obsidian .rte a {
+  color: var(--multirow-accent);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(90, 169, 230, 0.35);
+  transition: color 150ms ease, border-color 150ms ease;
+}
+
+.multirow--obsidian .rte a:hover {
+  color: var(--multirow-accent-strong);
+  border-color: rgba(122, 199, 255, 0.6);
+}
+
+.multirow--obsidian .button {
+  background: rgba(90, 169, 230, 0.16);
+  color: #e8ecf2;
+  border: 1px solid rgba(90, 169, 230, 0.4);
+  border-radius: calc(var(--multirow-radius) - 4px);
+  padding: 12px 18px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: none;
+  transition: background 150ms ease, border-color 150ms ease, transform 120ms ease;
+}
+
+.multirow--obsidian .button:hover {
+  background: rgba(122, 199, 255, 0.25);
+  border-color: rgba(122, 199, 255, 0.55);
+  transform: translateY(-1px);
+}
+
+.multirow--obsidian .button:focus-visible {
+  outline: 2px solid rgba(122, 199, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.multirow--obsidian .image-with-text__grid.grid--1-col {
+  row-gap: 0;
+}
+
+.multirow--obsidian .image-with-text__grid.grid--2-col-tablet,
+.multirow--obsidian .image-with-text__grid.grid--3-col-tablet {
+  column-gap: var(--multirow-gap);
+}
+
+@media screen and (min-width: 990px) {
+  .multirow--obsidian .image-with-text__grid.grid--reverse > .multirow__media {
+    order: 2;
+  }
+}
+
+.multirow--obsidian .image-with-text__content--middle {
+  align-items: center;
+}
+
+.multirow--obsidian .image-with-text__content--top {
+  align-items: flex-start;
+}
+
+.multirow--obsidian .image-with-text__content--bottom {
+  align-items: flex-end;
+}
+
+.multirow--obsidian .image-with-text__content--mobile-center,
+.multirow--obsidian .image-with-text__content--desktop-center {
+  text-align: left;
+}
+
+@media screen and (max-width: 749px) {
+  .multirow--obsidian .multirow__block {
+    border-radius: calc(var(--multirow-radius) + 2px);
+  }
+
+  .multirow--obsidian .multirow__content-inner {
+    border-radius: 0 0 var(--multirow-radius) var(--multirow-radius);
+  }
+
+  .multirow--obsidian .image-with-text__heading {
+    font-size: clamp(1.4rem, 5vw, 1.8rem);
+  }
+}

--- a/assets/multirow-obsidian.css
+++ b/assets/multirow-obsidian.css
@@ -1,12 +1,14 @@
 .multirow--obsidian .image-with-text__heading {
   font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
-  color: #e8ecf2;
+  color: #d2c5ff;
   letter-spacing: -0.01em;
+  text-shadow: 0 0 10px rgba(185, 150, 255, 0.22);
 }
 
 .multirow--obsidian .image-with-text__text {
-  color: #8d96a3;
+  color: #b2bed0;
   font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.7;
 }
 
 .multirow--obsidian .image-with-text__text--caption {
@@ -27,6 +29,46 @@
 .multirow--obsidian .rte a:hover {
   color: #7ac7ff;
   border-color: rgba(122, 199, 255, 0.6);
+}
+
+.multirow--obsidian .rte strong,
+.multirow--obsidian .rte b {
+  color: #f7e274;
+  font-weight: 700;
+  text-shadow: 0 0 10px rgba(247, 226, 116, 0.35);
+}
+
+.multirow--obsidian .rte em,
+.multirow--obsidian .rte i {
+  color: #d9f3ff;
+  font-style: italic;
+}
+
+.multirow--obsidian .rte u,
+.multirow--obsidian .rte ins {
+  text-decoration: underline;
+  text-decoration-color: rgba(122, 199, 255, 0.6);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+  color: #c7d6f1;
+}
+
+.multirow--obsidian .rte mark,
+.multirow--obsidian .rte .highlight {
+  background: rgba(247, 226, 116, 0.18);
+  color: #f7e274;
+  padding: 0.05em 0.18em;
+  border-radius: 4px;
+  box-shadow: 0 0 14px rgba(247, 226, 116, 0.25);
+}
+
+.multirow--obsidian .rte ul,
+.multirow--obsidian .rte ol {
+  color: #b2bed0;
+}
+
+.multirow--obsidian .rte li::marker {
+  color: rgba(90, 169, 230, 0.8);
 }
 
 .multirow--obsidian .button {

--- a/assets/multirow-obsidian.css
+++ b/assets/multirow-obsidian.css
@@ -37,9 +37,9 @@
 
 .multirow--obsidian .rte strong,
 .multirow--obsidian .rte b {
-  color: #91ffda;
+  color: #7ed0ff;
   font-weight: 700;
-  text-shadow: 0 0 10px rgba(145, 255, 218, 0.45);
+  text-shadow: 0 0 12px rgba(126, 199, 255, 0.55), 0 0 18px rgba(185, 176, 255, 0.35);
 }
 
 .multirow--obsidian .rte em,
@@ -61,18 +61,18 @@
 
 .multirow--obsidian .rte mark,
 .multirow--obsidian .rte .highlight {
-  background: radial-gradient(circle, rgba(115, 255, 223, 0.28) 0%, rgba(66, 130, 255, 0.18) 100%);
-  color: #91ffda;
+  background: radial-gradient(circle, rgba(126, 199, 255, 0.32) 0%, rgba(185, 176, 255, 0.26) 70%, rgba(145, 255, 218, 0.14) 100%);
+  color: #e6f0ff;
   padding: 0.05em 0.18em;
   border-radius: 4px;
-  box-shadow: 0 0 18px rgba(115, 255, 223, 0.35), 0 0 22px rgba(109, 152, 255, 0.25);
+  box-shadow: 0 0 18px rgba(126, 199, 255, 0.45), 0 0 24px rgba(185, 176, 255, 0.32), 0 0 26px rgba(145, 255, 218, 0.18);
 }
 
 .multirow--obsidian .rte sup,
 .multirow--obsidian .rte sub {
-  color: #9ed8ff;
+  color: #8ac5ff;
   font-size: 0.8em;
-  text-shadow: 0 0 10px rgba(158, 216, 255, 0.4);
+  text-shadow: 0 0 12px rgba(138, 197, 255, 0.45);
 }
 
 .multirow--obsidian .rte sup {
@@ -103,18 +103,18 @@
   letter-spacing: 0.01em;
   text-transform: none;
   transition: background 150ms ease, border-color 150ms ease, transform 120ms ease, box-shadow 150ms ease;
-  box-shadow: 0 10px 30px rgba(26, 31, 58, 0.5), 0 0 18px rgba(126, 199, 255, 0.35);
+  box-shadow: 0 10px 30px rgba(26, 31, 58, 0.5), 0 0 18px rgba(126, 199, 255, 0.45), 0 0 20px rgba(185, 176, 255, 0.28);
 }
 
 .multirow--obsidian .button:hover {
   background: linear-gradient(135deg, rgba(185, 176, 255, 0.24), rgba(126, 199, 255, 0.24));
   border-color: rgba(185, 176, 255, 0.65);
   transform: translateY(-1px);
-  box-shadow: 0 14px 34px rgba(26, 31, 58, 0.55), 0 0 22px rgba(145, 255, 218, 0.35);
+  box-shadow: 0 14px 34px rgba(26, 31, 58, 0.55), 0 0 24px rgba(126, 199, 255, 0.55), 0 0 26px rgba(185, 176, 255, 0.32);
 }
 
 .multirow--obsidian .button:focus-visible {
-  outline: 2px solid rgba(145, 255, 218, 0.85);
+  outline: 2px solid rgba(126, 199, 255, 0.85);
   outline-offset: 2px;
-  box-shadow: 0 0 18px rgba(145, 255, 218, 0.4);
+  box-shadow: 0 0 18px rgba(126, 199, 255, 0.6), 0 0 22px rgba(185, 176, 255, 0.32);
 }

--- a/assets/multirow-obsidian.css
+++ b/assets/multirow-obsidian.css
@@ -22,11 +22,11 @@
 }
 
 .multirow--obsidian .rte a {
-  color: #7ec7ff;
+  color: #63b5ff;
   text-decoration: none;
-  border-bottom: 1px solid rgba(126, 199, 255, 0.35);
+  border-bottom: 1px solid rgba(99, 181, 255, 0.35);
   transition: color 150ms ease, border-color 150ms ease, text-shadow 150ms ease;
-  text-shadow: 0 0 8px rgba(126, 199, 255, 0.35);
+  text-shadow: 0 0 8px rgba(99, 181, 255, 0.35);
 }
 
 .multirow--obsidian .rte a:hover {
@@ -37,16 +37,16 @@
 
 .multirow--obsidian .rte strong,
 .multirow--obsidian .rte b {
-  color: #7ed0ff;
+  color: #63b5ff;
   font-weight: 700;
-  text-shadow: 0 0 12px rgba(126, 199, 255, 0.55), 0 0 18px rgba(185, 176, 255, 0.35);
+  text-shadow: 0 0 12px rgba(99, 181, 255, 0.55), 0 0 18px rgba(185, 176, 255, 0.35);
 }
 
 .multirow--obsidian .rte em,
 .multirow--obsidian .rte i {
-  color: #f2e6ff;
+  color: #8bffc9;
   font-style: italic;
-  text-shadow: 0 0 12px rgba(211, 180, 255, 0.35);
+  text-shadow: 0 0 12px rgba(139, 255, 201, 0.45), 0 0 18px rgba(111, 233, 177, 0.35);
 }
 
 .multirow--obsidian .rte u,
@@ -70,9 +70,9 @@
 
 .multirow--obsidian .rte sup,
 .multirow--obsidian .rte sub {
-  color: #8ac5ff;
+  color: #6cb0ff;
   font-size: 0.8em;
-  text-shadow: 0 0 12px rgba(138, 197, 255, 0.45);
+  text-shadow: 0 0 12px rgba(108, 176, 255, 0.45);
 }
 
 .multirow--obsidian .rte sup {
@@ -94,27 +94,27 @@
 }
 
 .multirow--obsidian .button {
-  background: linear-gradient(135deg, rgba(126, 199, 255, 0.16), rgba(185, 176, 255, 0.14));
+  background: linear-gradient(135deg, rgba(99, 181, 255, 0.16), rgba(185, 176, 255, 0.14));
   color: #f2f5ff;
-  border: 1px solid rgba(126, 199, 255, 0.45);
+  border: 1px solid rgba(99, 181, 255, 0.45);
   border-radius: 12px;
   padding: 12px 18px;
   font-weight: 600;
   letter-spacing: 0.01em;
   text-transform: none;
   transition: background 150ms ease, border-color 150ms ease, transform 120ms ease, box-shadow 150ms ease;
-  box-shadow: 0 10px 30px rgba(26, 31, 58, 0.5), 0 0 18px rgba(126, 199, 255, 0.45), 0 0 20px rgba(185, 176, 255, 0.28);
+  box-shadow: 0 10px 30px rgba(26, 31, 58, 0.5), 0 0 18px rgba(99, 181, 255, 0.45), 0 0 20px rgba(185, 176, 255, 0.28);
 }
 
 .multirow--obsidian .button:hover {
-  background: linear-gradient(135deg, rgba(185, 176, 255, 0.24), rgba(126, 199, 255, 0.24));
+  background: linear-gradient(135deg, rgba(185, 176, 255, 0.24), rgba(99, 181, 255, 0.24));
   border-color: rgba(185, 176, 255, 0.65);
   transform: translateY(-1px);
-  box-shadow: 0 14px 34px rgba(26, 31, 58, 0.55), 0 0 24px rgba(126, 199, 255, 0.55), 0 0 26px rgba(185, 176, 255, 0.32);
+  box-shadow: 0 14px 34px rgba(26, 31, 58, 0.55), 0 0 24px rgba(99, 181, 255, 0.55), 0 0 26px rgba(185, 176, 255, 0.32);
 }
 
 .multirow--obsidian .button:focus-visible {
-  outline: 2px solid rgba(126, 199, 255, 0.85);
+  outline: 2px solid rgba(99, 181, 255, 0.85);
   outline-offset: 2px;
-  box-shadow: 0 0 18px rgba(126, 199, 255, 0.6), 0 0 22px rgba(185, 176, 255, 0.32);
+  box-shadow: 0 0 18px rgba(99, 181, 255, 0.6), 0 0 22px rgba(185, 176, 255, 0.32);
 }

--- a/assets/multirow-obsidian.css
+++ b/assets/multirow-obsidian.css
@@ -1,59 +1,3 @@
-.multirow--obsidian {
-  --multirow-bg: #0f1115;
-  --multirow-card: #141820;
-  --multirow-card-border: #1e2530;
-  --multirow-text: #c6cbd4;
-  --multirow-muted: #8d96a3;
-  --multirow-accent: #5aa9e6;
-  --multirow-accent-strong: #7ac7ff;
-  --multirow-radius: 16px;
-  --multirow-gap: clamp(16px, 3vw, 28px);
-  --multirow-shadow: 0 18px 40px rgba(6, 10, 14, 0.45);
-}
-
-.multirow--obsidian .multirow__block {
-  position: relative;
-  isolation: isolate;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
-  border: 1px solid var(--multirow-card-border);
-  border-radius: var(--multirow-radius);
-  box-shadow: var(--multirow-shadow);
-  overflow: hidden;
-  color: var(--multirow-text);
-  transition: transform 150ms ease, border-color 200ms ease, box-shadow 200ms ease;
-}
-
-.multirow--obsidian .multirow__block:hover {
-  transform: translateY(-2px);
-  border-color: rgba(122, 199, 255, 0.45);
-  box-shadow: 0 20px 48px rgba(10, 16, 24, 0.6);
-}
-
-.multirow--obsidian .multirow__media .image-with-text__media {
-  border-radius: var(--multirow-radius) 0 0 var(--multirow-radius);
-  border: 1px solid var(--multirow-card-border);
-  background: #0b0d11;
-  overflow: hidden;
-  height: 100%;
-}
-
-@media screen and (max-width: 749px) {
-  .multirow--obsidian .multirow__media .image-with-text__media {
-    border-radius: var(--multirow-radius) var(--multirow-radius) 0 0;
-  }
-}
-
-.multirow--obsidian .multirow__content-inner {
-  position: relative;
-  background: var(--multirow-card);
-  border-radius: var(--multirow-radius);
-  border: 1px solid var(--multirow-card-border);
-  color: var(--multirow-text);
-  padding: clamp(20px, 2vw, 28px);
-  display: grid;
-  gap: 10px;
-}
-
 .multirow--obsidian .image-with-text__heading {
   font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
   color: #e8ecf2;
@@ -61,27 +5,27 @@
 }
 
 .multirow--obsidian .image-with-text__text {
-  color: var(--multirow-muted);
+  color: #8d96a3;
   font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
 }
 
 .multirow--obsidian .image-with-text__text--caption {
   font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
-  color: var(--multirow-accent);
+  color: #5aa9e6;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.78rem;
 }
 
 .multirow--obsidian .rte a {
-  color: var(--multirow-accent);
+  color: #5aa9e6;
   text-decoration: none;
   border-bottom: 1px solid rgba(90, 169, 230, 0.35);
   transition: color 150ms ease, border-color 150ms ease;
 }
 
 .multirow--obsidian .rte a:hover {
-  color: var(--multirow-accent-strong);
+  color: #7ac7ff;
   border-color: rgba(122, 199, 255, 0.6);
 }
 
@@ -89,7 +33,7 @@
   background: rgba(90, 169, 230, 0.16);
   color: #e8ecf2;
   border: 1px solid rgba(90, 169, 230, 0.4);
-  border-radius: calc(var(--multirow-radius) - 4px);
+  border-radius: 12px;
   padding: 12px 18px;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -106,18 +50,4 @@
 .multirow--obsidian .button:focus-visible {
   outline: 2px solid rgba(122, 199, 255, 0.7);
   outline-offset: 2px;
-}
-
-@media screen and (max-width: 749px) {
-  .multirow--obsidian .multirow__block {
-    border-radius: calc(var(--multirow-radius) + 2px);
-  }
-
-  .multirow--obsidian .multirow__content-inner {
-    border-radius: 0 0 var(--multirow-radius) var(--multirow-radius);
-  }
-
-  .multirow--obsidian .image-with-text__heading {
-    font-size: clamp(1.4rem, 5vw, 1.8rem);
-  }
 }

--- a/assets/multirow-obsidian.css
+++ b/assets/multirow-obsidian.css
@@ -1,95 +1,120 @@
 .multirow--obsidian .image-with-text__heading {
   font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
-  color: #d2c5ff;
+  color: #d6b9ff;
   letter-spacing: -0.01em;
-  text-shadow: 0 0 10px rgba(185, 150, 255, 0.22);
+  text-shadow: 0 0 18px rgba(162, 116, 255, 0.4), 0 0 36px rgba(88, 172, 255, 0.18);
 }
 
 .multirow--obsidian .image-with-text__text {
-  color: #b2bed0;
+  color: #c9d6ff;
   font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
   line-height: 1.7;
+  text-shadow: 0 0 10px rgba(94, 138, 255, 0.15);
 }
 
 .multirow--obsidian .image-with-text__text--caption {
   font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
-  color: #5aa9e6;
+  color: #72d5ff;
   text-transform: uppercase;
   letter-spacing: 0.14em;
   font-size: 0.78rem;
+  text-shadow: 0 0 10px rgba(114, 213, 255, 0.35);
 }
 
 .multirow--obsidian .rte a {
-  color: #5aa9e6;
+  color: #7ec7ff;
   text-decoration: none;
-  border-bottom: 1px solid rgba(90, 169, 230, 0.35);
-  transition: color 150ms ease, border-color 150ms ease;
+  border-bottom: 1px solid rgba(126, 199, 255, 0.35);
+  transition: color 150ms ease, border-color 150ms ease, text-shadow 150ms ease;
+  text-shadow: 0 0 8px rgba(126, 199, 255, 0.35);
 }
 
 .multirow--obsidian .rte a:hover {
-  color: #7ac7ff;
-  border-color: rgba(122, 199, 255, 0.6);
+  color: #b9b0ff;
+  border-color: rgba(185, 176, 255, 0.65);
+  text-shadow: 0 0 14px rgba(185, 176, 255, 0.65);
 }
 
 .multirow--obsidian .rte strong,
 .multirow--obsidian .rte b {
-  color: #f7e274;
+  color: #91ffda;
   font-weight: 700;
-  text-shadow: 0 0 10px rgba(247, 226, 116, 0.35);
+  text-shadow: 0 0 10px rgba(145, 255, 218, 0.45);
 }
 
 .multirow--obsidian .rte em,
 .multirow--obsidian .rte i {
-  color: #d9f3ff;
+  color: #f2e6ff;
   font-style: italic;
+  text-shadow: 0 0 12px rgba(211, 180, 255, 0.35);
 }
 
 .multirow--obsidian .rte u,
 .multirow--obsidian .rte ins {
   text-decoration: underline;
-  text-decoration-color: rgba(122, 199, 255, 0.6);
+  text-decoration-color: rgba(151, 204, 255, 0.75);
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
-  color: #c7d6f1;
+  color: #d6e4ff;
+  text-shadow: 0 0 12px rgba(151, 204, 255, 0.5);
 }
 
 .multirow--obsidian .rte mark,
 .multirow--obsidian .rte .highlight {
-  background: rgba(247, 226, 116, 0.18);
-  color: #f7e274;
+  background: radial-gradient(circle, rgba(115, 255, 223, 0.28) 0%, rgba(66, 130, 255, 0.18) 100%);
+  color: #91ffda;
   padding: 0.05em 0.18em;
   border-radius: 4px;
-  box-shadow: 0 0 14px rgba(247, 226, 116, 0.25);
+  box-shadow: 0 0 18px rgba(115, 255, 223, 0.35), 0 0 22px rgba(109, 152, 255, 0.25);
+}
+
+.multirow--obsidian .rte sup,
+.multirow--obsidian .rte sub {
+  color: #9ed8ff;
+  font-size: 0.8em;
+  text-shadow: 0 0 10px rgba(158, 216, 255, 0.4);
+}
+
+.multirow--obsidian .rte sup {
+  vertical-align: super;
+}
+
+.multirow--obsidian .rte sub {
+  vertical-align: sub;
 }
 
 .multirow--obsidian .rte ul,
 .multirow--obsidian .rte ol {
-  color: #b2bed0;
+  color: #c9d6ff;
 }
 
 .multirow--obsidian .rte li::marker {
-  color: rgba(90, 169, 230, 0.8);
+  color: rgba(185, 176, 255, 0.85);
+  text-shadow: 0 0 10px rgba(185, 176, 255, 0.4);
 }
 
 .multirow--obsidian .button {
-  background: rgba(90, 169, 230, 0.16);
-  color: #e8ecf2;
-  border: 1px solid rgba(90, 169, 230, 0.4);
+  background: linear-gradient(135deg, rgba(126, 199, 255, 0.16), rgba(185, 176, 255, 0.14));
+  color: #f2f5ff;
+  border: 1px solid rgba(126, 199, 255, 0.45);
   border-radius: 12px;
   padding: 12px 18px;
   font-weight: 600;
   letter-spacing: 0.01em;
   text-transform: none;
-  transition: background 150ms ease, border-color 150ms ease, transform 120ms ease;
+  transition: background 150ms ease, border-color 150ms ease, transform 120ms ease, box-shadow 150ms ease;
+  box-shadow: 0 10px 30px rgba(26, 31, 58, 0.5), 0 0 18px rgba(126, 199, 255, 0.35);
 }
 
 .multirow--obsidian .button:hover {
-  background: rgba(122, 199, 255, 0.25);
-  border-color: rgba(122, 199, 255, 0.55);
+  background: linear-gradient(135deg, rgba(185, 176, 255, 0.24), rgba(126, 199, 255, 0.24));
+  border-color: rgba(185, 176, 255, 0.65);
   transform: translateY(-1px);
+  box-shadow: 0 14px 34px rgba(26, 31, 58, 0.55), 0 0 22px rgba(145, 255, 218, 0.35);
 }
 
 .multirow--obsidian .button:focus-visible {
-  outline: 2px solid rgba(122, 199, 255, 0.7);
+  outline: 2px solid rgba(145, 255, 218, 0.85);
   outline-offset: 2px;
+  box-shadow: 0 0 18px rgba(145, 255, 218, 0.4);
 }

--- a/assets/multirow-obsidian.css
+++ b/assets/multirow-obsidian.css
@@ -11,12 +11,6 @@
   --multirow-shadow: 0 18px 40px rgba(6, 10, 14, 0.45);
 }
 
-.multirow--obsidian .multirow__inner {
-  display: grid;
-  gap: var(--multirow-gap);
-  padding-inline: clamp(10px, 3vw, 22px);
-}
-
 .multirow--obsidian .multirow__block {
   position: relative;
   isolation: isolate;
@@ -35,11 +29,6 @@
   box-shadow: 0 20px 48px rgba(10, 16, 24, 0.6);
 }
 
-.multirow--obsidian .multirow__grid {
-  gap: var(--multirow-gap);
-  align-items: stretch;
-}
-
 .multirow--obsidian .multirow__media .image-with-text__media {
   border-radius: var(--multirow-radius) 0 0 var(--multirow-radius);
   border: 1px solid var(--multirow-card-border);
@@ -52,11 +41,6 @@
   .multirow--obsidian .multirow__media .image-with-text__media {
     border-radius: var(--multirow-radius) var(--multirow-radius) 0 0;
   }
-}
-
-.multirow--obsidian .multirow__content {
-  display: flex;
-  align-items: stretch;
 }
 
 .multirow--obsidian .multirow__content-inner {
@@ -122,38 +106,6 @@
 .multirow--obsidian .button:focus-visible {
   outline: 2px solid rgba(122, 199, 255, 0.7);
   outline-offset: 2px;
-}
-
-.multirow--obsidian .image-with-text__grid.grid--1-col {
-  row-gap: 0;
-}
-
-.multirow--obsidian .image-with-text__grid.grid--2-col-tablet,
-.multirow--obsidian .image-with-text__grid.grid--3-col-tablet {
-  column-gap: var(--multirow-gap);
-}
-
-@media screen and (min-width: 990px) {
-  .multirow--obsidian .image-with-text__grid.grid--reverse > .multirow__media {
-    order: 2;
-  }
-}
-
-.multirow--obsidian .image-with-text__content--middle {
-  align-items: center;
-}
-
-.multirow--obsidian .image-with-text__content--top {
-  align-items: flex-start;
-}
-
-.multirow--obsidian .image-with-text__content--bottom {
-  align-items: flex-end;
-}
-
-.multirow--obsidian .image-with-text__content--mobile-center,
-.multirow--obsidian .image-with-text__content--desktop-center {
-  text-align: left;
 }
 
 @media screen and (max-width: 749px) {

--- a/sections/multirow.liquid
+++ b/sections/multirow.liquid
@@ -1,4 +1,5 @@
 {{ 'component-image-with-text.css' | asset_url | stylesheet_tag }}
+{{ 'multirow-obsidian.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
   .section-{{ section.id }}-padding {
@@ -42,15 +43,17 @@
   endunless
 -%}
 
-<div class="multirow section-{{ section.id }}-padding gradient color-{{ section.settings.section_color_scheme }}">
+<div class="multirow multirow--obsidian section-{{ section.id }}-padding gradient color-{{ section.settings.section_color_scheme }}">
   <div class="multirow__inner page-width">
     {%- for block in section.blocks -%}
       <div
-        class="image-with-text isolate{{ borders_class }}{{ corners_class }}{{ padding_class }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
+        class="multirow__block image-with-text isolate{{ borders_class }}{{ corners_class }}{{ padding_class }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
+        data-multirow-block-id="{{ block.id }}"
+        data-multirow-block-type="row"
         {{ block.shopify_attributes }}
       >
-        <div class="image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %}{% cycle odd_class, even_class %}{% else %}{{ odd_class }}{% endif %}">
-          <div class="image-with-text__media-item image-with-text__media-item--{{ section.settings.desktop_image_width }} image-with-text__media-item--{{ section.settings.desktop_content_position }} grid__item">
+        <div class="multirow__grid image-with-text__grid grid grid--gapless grid--1-col grid--{% if section.settings.desktop_image_width == 'medium' %}2-col-tablet{% else %}3-col-tablet{% endif %}{% if section.settings.image_layout contains 'alternate' %}{% cycle odd_class, even_class %}{% else %}{{ odd_class }}{% endif %}">
+          <div class="multirow__media image-with-text__media-item image-with-text__media-item--{{ section.settings.desktop_image_width }} image-with-text__media-item--{{ section.settings.desktop_content_position }} grid__item">
             <div
               class="image-with-text__media image-with-text__media--{{ section.settings.image_height }} gradient color-{{ section.settings.row_color_scheme }} global-media-settings{% if block.settings.image != blank %} media{% else %} image-with-text__media--placeholder placeholder{% endif %}"
               {% if section.settings.image_height == 'adapt' and block.settings.image != blank %}
@@ -72,8 +75,8 @@
               {%- endif -%}
             </div>
           </div>
-          <div class="image-with-text__text-item grid__item">
-            <div class="image-with-text__content image-with-text__content--{{ section.settings.desktop_content_position }} image-with-text__content--desktop-{{ section.settings.desktop_content_alignment }} image-with-text__content--mobile-{{ section.settings.mobile_content_alignment }} image-with-text__content--{{ section.settings.image_height }} content-container{% unless no_content_background and no_content_styles %} gradient color-{{ section.settings.row_color_scheme }}{% else %} background-transparent{% endunless %}">
+          <div class="multirow__content image-with-text__text-item grid__item">
+            <div class="multirow__content-inner image-with-text__content image-with-text__content--{{ section.settings.desktop_content_position }} image-with-text__content--desktop-{{ section.settings.desktop_content_alignment }} image-with-text__content--mobile-{{ section.settings.mobile_content_alignment }} image-with-text__content--{{ section.settings.image_height }} content-container{% unless no_content_background and no_content_styles %} gradient color-{{ section.settings.row_color_scheme }}{% else %} background-transparent{% endunless %}">
               {%- if block.settings.caption -%}
                 <p class="image-with-text__text image-with-text__text--caption caption-with-letter-spacing caption-with-letter-spacing--medium">
                   {{ block.settings.caption | escape }}


### PR DESCRIPTION
## Summary
- add dedicated multirow Obsidian stylesheet for card-like Knowledge Hub styling
- attach unique classes and data attributes to multirow blocks for targeted theming

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252870b4d0832886d50dde3924753a)