### PR TITLE
Add video banner section with YouTube/Vimeo support

### DIFF
--- a/assets/section-video-banner.css
+++ b/assets/section-video-banner.css
@@ -11,6 +11,11 @@
   border: none;
 }
 
+.video-banner .banner__media {
+  background-color: #000;
+}
+
+/* Mobile image fallback */
 .video-banner__mobile-image {
   display: none;
 }
@@ -35,4 +40,46 @@
     width: 100%;
     height: 100%;
   }
+}
+
+/* Play/pause button */
+.video-banner__play-pause {
+  position: absolute;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 3;
+  background: rgba(var(--color-background), 0.5);
+  border: 0.1rem solid rgba(var(--color-foreground), 0.1);
+  border-radius: 50%;
+  color: rgb(var(--color-foreground));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 4.4rem;
+  width: 4.4rem;
+  padding: 0;
+  transition: background-color 0.2s ease;
+}
+
+.video-banner__play-pause:hover {
+  background: rgba(var(--color-background), 0.75);
+}
+
+.video-banner__play-pause .svg-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+}
+
+.video-banner__play-pause .icon {
+  width: 1.4rem;
+  height: 1.4rem;
+}
+
+video-banner-component {
+  display: block;
+  position: relative;
 }

--- a/assets/section-video-banner.css
+++ b/assets/section-video-banner.css
@@ -1,0 +1,38 @@
+/* Video Banner - video-specific styles (layout shared via section-image-banner.css) */
+
+.video-banner video,
+.video-banner iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: none;
+}
+
+.video-banner__mobile-image {
+  display: none;
+}
+
+.video-banner__mobile-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+@media screen and (max-width: 749px) {
+  .video-banner--mobile-image .video-banner__media video,
+  .video-banner--mobile-image .video-banner__media iframe {
+    display: none;
+  }
+
+  .video-banner--mobile-image .video-banner__mobile-image {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/assets/video-banner.js
+++ b/assets/video-banner.js
@@ -1,0 +1,115 @@
+if (!customElements.get('video-banner-component')) {
+  class VideoBannerComponent extends HTMLElement {
+    constructor() {
+      super();
+      this.paused = false;
+      this.offscreen = false;
+      this.playPauseButton = this.querySelector('.video-banner__play-pause');
+      this.pauseIcon = this.querySelector('.video-banner__pause-icon');
+      this.playIcon = this.querySelector('.video-banner__play-icon');
+
+      if (this.playPauseButton) {
+        this.playPauseButton.addEventListener('click', this.togglePlayback.bind(this));
+      }
+
+      if (this.dataset.pauseOffscreen === 'true') {
+        this.setupIntersectionObserver();
+      }
+    }
+
+    setupIntersectionObserver() {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              this.offscreen = false;
+              if (!this.paused) this.playMedia();
+            } else {
+              this.offscreen = true;
+              this.pauseMedia();
+            }
+          });
+        },
+        { threshold: 0.25 }
+      );
+      observer.observe(this);
+    }
+
+    togglePlayback() {
+      this.paused = !this.paused;
+      if (this.paused) {
+        this.pauseMedia();
+      } else {
+        this.playMedia();
+      }
+      this.updateUI();
+    }
+
+    playMedia() {
+      const video = this.querySelector('.banner__media video');
+      if (video) {
+        video.play().catch(() => {});
+        return;
+      }
+
+      const ytIframe = this.querySelector('.banner__media iframe.js-youtube');
+      if (ytIframe) {
+        try {
+          ytIframe.contentWindow.postMessage(
+            JSON.stringify({ event: 'command', func: 'playVideo', args: '' }),
+            '*'
+          );
+        } catch (e) {}
+        return;
+      }
+
+      const vimeoIframe = this.querySelector('.banner__media iframe.js-vimeo');
+      if (vimeoIframe) {
+        try {
+          vimeoIframe.contentWindow.postMessage(JSON.stringify({ method: 'play' }), '*');
+        } catch (e) {}
+      }
+    }
+
+    pauseMedia() {
+      const video = this.querySelector('.banner__media video');
+      if (video) {
+        video.pause();
+        return;
+      }
+
+      const ytIframe = this.querySelector('.banner__media iframe.js-youtube');
+      if (ytIframe) {
+        try {
+          ytIframe.contentWindow.postMessage(
+            JSON.stringify({ event: 'command', func: 'pauseVideo', args: '' }),
+            '*'
+          );
+        } catch (e) {}
+        return;
+      }
+
+      const vimeoIframe = this.querySelector('.banner__media iframe.js-vimeo');
+      if (vimeoIframe) {
+        try {
+          vimeoIframe.contentWindow.postMessage(JSON.stringify({ method: 'pause' }), '*');
+        } catch (e) {}
+      }
+    }
+
+    updateUI() {
+      if (!this.playPauseButton) return;
+      if (this.paused) {
+        this.pauseIcon.hidden = true;
+        this.playIcon.hidden = false;
+        this.playPauseButton.setAttribute('aria-label', 'Play video');
+      } else {
+        this.pauseIcon.hidden = false;
+        this.playIcon.hidden = true;
+        this.playPauseButton.setAttribute('aria-label', 'Pause video');
+      }
+    }
+  }
+
+  customElements.define('video-banner-component', VideoBannerComponent);
+}

--- a/assets/video-banner.js
+++ b/assets/video-banner.js
@@ -17,6 +17,22 @@ if (!customElements.get('video-banner-component')) {
       }
     }
 
+    connectedCallback() {
+      const video = this.querySelector('.banner__media video');
+      if (video) {
+        const attemptPlay = () => {
+          if (!this.paused && !this.offscreen) {
+            video.play().catch(() => {});
+          }
+        };
+        if (video.readyState >= 2) {
+          attemptPlay();
+        } else {
+          video.addEventListener('loadeddata', attemptPlay, { once: true });
+        }
+      }
+    }
+
     setupIntersectionObserver() {
       const observer = new IntersectionObserver(
         (entries) => {

--- a/sections/video-banner.liquid
+++ b/sections/video-banner.liquid
@@ -1,0 +1,399 @@
+{{ 'section-image-banner.css' | asset_url | stylesheet_tag }}
+{{ 'section-video-banner.css' | asset_url | stylesheet_tag }}
+
+{%- style -%}
+  #Banner-{{ section.id }}::after {
+    opacity: {{ section.settings.image_overlay_opacity | divided_by: 100.0 }};
+  }
+{%- endstyle -%}
+
+{%- liquid
+  assign video_id = section.settings.video_url.id
+  assign video_alt = section.settings.video_url.id | default: 'Video banner'
+-%}
+
+<div
+  id="Banner-{{ section.id }}"
+  class="banner video-banner banner--content-align-{{ section.settings.desktop_content_alignment }} banner--content-align-mobile-{{ section.settings.mobile_content_alignment }} banner--{{ section.settings.video_height }}{% if section.settings.show_text_below %} banner--mobile-bottom{% endif %}{% if section.settings.show_text_box == false %} banner--desktop-transparent{% endif %}{% if section.settings.show_image_on_mobile and section.settings.cover_image != blank %} video-banner--mobile-image{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+>
+  <div class="banner__media video-banner__media media{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}">
+    {%- if section.settings.video != blank -%}
+      {{
+        section.settings.video
+        | video_tag:
+          image_size: '1920x',
+          autoplay: true,
+          loop: section.settings.enable_video_looping,
+          controls: false,
+          muted: true,
+          playsinline: true
+      }}
+    {%- elsif section.settings.video_url != blank -%}
+      {%- if section.settings.video_url.type == 'youtube' -%}
+        {%- liquid
+          assign loop_param = ''
+          if section.settings.enable_video_looping
+            assign loop_param = '&loop=1&playlist=' | append: video_id
+          endif
+        -%}
+        <iframe
+          src="https://www.youtube.com/embed/{{ video_id }}?enablejsapi=1&autoplay=1&mute=1&controls=0&showinfo=0&rel=0{{ loop_param }}"
+          allow="autoplay; encrypted-media"
+          allowfullscreen
+          title="{{ video_alt | escape }}"
+        ></iframe>
+      {%- else -%}
+        {%- liquid
+          assign loop_param = ''
+          if section.settings.enable_video_looping
+            assign loop_param = '&loop=1'
+          endif
+        -%}
+        <iframe
+          src="https://player.vimeo.com/video/{{ video_id }}?autoplay=1&muted=1&controls=0&background=1{{ loop_param }}"
+          allow="autoplay; encrypted-media"
+          allowfullscreen
+          title="{{ video_alt | escape }}"
+        ></iframe>
+      {%- endif -%}
+    {%- elsif section.settings.cover_image != blank -%}
+      {%- liquid
+        assign cover_height = section.settings.cover_image.width | divided_by: section.settings.cover_image.aspect_ratio | round
+      -%}
+      {{
+        section.settings.cover_image
+        | image_url: width: 3840
+        | image_tag: sizes: '100vw', widths: '375, 750, 1100, 1500, 1780, 2000, 3000, 3840', height: cover_height
+      }}
+    {%- else -%}
+      {{ 'hero-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
+    {%- endif -%}
+
+    {%- if section.settings.show_image_on_mobile and section.settings.cover_image != blank -%}
+      <div class="video-banner__mobile-image">
+        {%- liquid
+          assign cover_height = section.settings.cover_image.width | divided_by: section.settings.cover_image.aspect_ratio | round
+        -%}
+        {{
+          section.settings.cover_image
+          | image_url: width: 1500
+          | image_tag: sizes: '100vw', widths: '375, 550, 750, 1100, 1500', height: cover_height
+        }}
+      </div>
+    {%- endif -%}
+  </div>
+
+  <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
+    <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient">
+      {%- for block in section.blocks -%}
+        {%- case block.type -%}
+          {%- when 'heading' -%}
+            <h2
+              class="banner__heading inline-richtext {{ block.settings.heading_size }}"
+              {{ block.shopify_attributes }}
+            >
+              {{ block.settings.heading }}
+            </h2>
+          {%- when 'text' -%}
+            <div class="banner__text rte {{ block.settings.text_style }}" {{ block.shopify_attributes }}>
+              <p>{{ block.settings.text }}</p>
+            </div>
+          {%- when 'buttons' -%}
+            <div
+              class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_label_2 != blank %} banner__buttons--multiple{% endif %}"
+              {{ block.shopify_attributes }}
+            >
+              {%- if block.settings.button_label_1 != blank -%}
+                <a
+                  {% if block.settings.button_link_1 == blank %}
+                    role="link" aria-disabled="true"
+                  {% else %}
+                    href="{{ block.settings.button_link_1 }}"
+                  {% endif %}
+                  class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"
+                >
+                  {{- block.settings.button_label_1 | escape -}}
+                </a>
+              {%- endif -%}
+              {%- if block.settings.button_label_2 != blank -%}
+                <a
+                  {% if block.settings.button_link_2 == blank %}
+                    role="link" aria-disabled="true"
+                  {% else %}
+                    href="{{ block.settings.button_link_2 }}"
+                  {% endif %}
+                  class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"
+                >
+                  {{- block.settings.button_label_2 | escape -}}
+                </a>
+              {%- endif -%}
+            </div>
+        {%- endcase -%}
+      {%- endfor -%}
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Video banner",
+  "tag": "section",
+  "class": "section",
+  "disabled_on": {
+    "groups": ["header", "footer"]
+  },
+  "settings": [
+    {
+      "type": "header",
+      "content": "Shopify-hosted video"
+    },
+    {
+      "type": "video",
+      "id": "video",
+      "label": "Video"
+    },
+    {
+      "type": "header",
+      "content": "Or embed video URL"
+    },
+    {
+      "type": "paragraph",
+      "content": "Use a YouTube or Vimeo URL. Shopify-hosted video takes priority if both are set."
+    },
+    {
+      "type": "video_url",
+      "id": "video_url",
+      "accept": ["youtube", "vimeo"],
+      "label": "Video URL",
+      "info": "Accepts YouTube and Vimeo URLs."
+    },
+    {
+      "type": "image_picker",
+      "id": "cover_image",
+      "label": "Cover image",
+      "info": "Displayed when no video is set, or as a mobile fallback."
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_video_looping",
+      "label": "Loop video",
+      "default": true
+    },
+    {
+      "type": "range",
+      "id": "image_overlay_opacity",
+      "min": 0,
+      "max": 100,
+      "step": 10,
+      "unit": "%",
+      "label": "Overlay opacity",
+      "default": 40
+    },
+    {
+      "type": "select",
+      "id": "video_height",
+      "options": [
+        {
+          "value": "small",
+          "label": "Small"
+        },
+        {
+          "value": "medium",
+          "label": "Medium"
+        },
+        {
+          "value": "large",
+          "label": "Large"
+        }
+      ],
+      "default": "medium",
+      "label": "Height"
+    },
+    {
+      "type": "header",
+      "content": "Content"
+    },
+    {
+      "type": "select",
+      "id": "desktop_content_position",
+      "options": [
+        { "value": "top-left", "label": "Top left" },
+        { "value": "top-center", "label": "Top center" },
+        { "value": "top-right", "label": "Top right" },
+        { "value": "middle-left", "label": "Middle left" },
+        { "value": "middle-center", "label": "Middle center" },
+        { "value": "middle-right", "label": "Middle right" },
+        { "value": "bottom-left", "label": "Bottom left" },
+        { "value": "bottom-center", "label": "Bottom center" },
+        { "value": "bottom-right", "label": "Bottom right" }
+      ],
+      "default": "middle-center",
+      "label": "Position"
+    },
+    {
+      "type": "select",
+      "id": "desktop_content_alignment",
+      "options": [
+        { "value": "left", "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right", "label": "Right" }
+      ],
+      "default": "center",
+      "label": "Alignment"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_text_box",
+      "label": "Show text box",
+      "default": true
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "Color scheme",
+      "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "Mobile"
+    },
+    {
+      "type": "select",
+      "id": "mobile_content_alignment",
+      "options": [
+        { "value": "left", "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right", "label": "Right" }
+      ],
+      "default": "center",
+      "label": "Mobile alignment"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_text_below",
+      "label": "Show text below video on mobile",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "show_image_on_mobile",
+      "label": "Show cover image on mobile instead of video",
+      "default": false,
+      "info": "Improves mobile performance by replacing the video with the cover image."
+    }
+  ],
+  "blocks": [
+    {
+      "type": "heading",
+      "name": "Heading",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "inline_richtext",
+          "id": "heading",
+          "default": "Video banner",
+          "label": "Heading"
+        },
+        {
+          "type": "select",
+          "id": "heading_size",
+          "options": [
+            { "value": "h2", "label": "Small" },
+            { "value": "h1", "label": "Medium" },
+            { "value": "h0", "label": "Large" },
+            { "value": "hxl", "label": "Extra large" },
+            { "value": "hxxl", "label": "Extra extra large" }
+          ],
+          "default": "h1",
+          "label": "Heading size"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "name": "Text",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "inline_richtext",
+          "id": "text",
+          "default": "Give customers details about the banner video or content on the template.",
+          "label": "Text"
+        },
+        {
+          "type": "select",
+          "id": "text_style",
+          "options": [
+            { "value": "body", "label": "Body" },
+            { "value": "subtitle", "label": "Subtitle" },
+            { "value": "caption-with-letter-spacing", "label": "Caption" }
+          ],
+          "default": "body",
+          "label": "Text style"
+        }
+      ]
+    },
+    {
+      "type": "buttons",
+      "name": "Buttons",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "header",
+          "content": "Button 1"
+        },
+        {
+          "type": "text",
+          "id": "button_label_1",
+          "default": "Button label",
+          "label": "Button label",
+          "info": "Leave blank to hide button."
+        },
+        {
+          "type": "url",
+          "id": "button_link_1",
+          "label": "Button link"
+        },
+        {
+          "type": "checkbox",
+          "id": "button_style_secondary_1",
+          "default": false,
+          "label": "Use outline button style"
+        },
+        {
+          "type": "header",
+          "content": "Button 2"
+        },
+        {
+          "type": "text",
+          "id": "button_label_2",
+          "default": "Button label",
+          "label": "Button label",
+          "info": "Leave blank to hide button."
+        },
+        {
+          "type": "url",
+          "id": "button_link_2",
+          "label": "Button link"
+        },
+        {
+          "type": "checkbox",
+          "id": "button_style_secondary_2",
+          "default": false,
+          "label": "Use outline button style"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Video banner",
+      "blocks": [
+        { "type": "heading" },
+        { "type": "text" },
+        { "type": "buttons" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/video-banner.liquid
+++ b/sections/video-banner.liquid
@@ -10,129 +10,161 @@
 {%- liquid
   assign video_id = section.settings.video_url.id
   assign video_alt = section.settings.video_url.id | default: 'Video banner'
+  assign has_video = false
+  if section.settings.video != blank or section.settings.video_url != blank
+    assign has_video = true
+  endif
 -%}
 
-<div
-  id="Banner-{{ section.id }}"
-  class="banner video-banner banner--content-align-{{ section.settings.desktop_content_alignment }} banner--content-align-mobile-{{ section.settings.mobile_content_alignment }} banner--{{ section.settings.video_height }}{% if section.settings.show_text_below %} banner--mobile-bottom{% endif %}{% if section.settings.show_text_box == false %} banner--desktop-transparent{% endif %}{% if section.settings.show_image_on_mobile and section.settings.cover_image != blank %} video-banner--mobile-image{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+<video-banner-component
+  id="VideoBanner-{{ section.id }}"
+  {% if section.settings.pause_offscreen %}data-pause-offscreen="true"{% endif %}
 >
-  <div class="banner__media video-banner__media media{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}">
-    {%- if section.settings.video != blank -%}
-      {{
-        section.settings.video
-        | video_tag:
-          image_size: '1920x',
-          autoplay: true,
-          loop: section.settings.enable_video_looping,
-          controls: false,
-          muted: true,
-          playsinline: true
-      }}
-    {%- elsif section.settings.video_url != blank -%}
-      {%- if section.settings.video_url.type == 'youtube' -%}
-        {%- liquid
-          assign loop_param = ''
-          if section.settings.enable_video_looping
-            assign loop_param = '&loop=1&playlist=' | append: video_id
-          endif
-        -%}
-        <iframe
-          src="https://www.youtube.com/embed/{{ video_id }}?enablejsapi=1&autoplay=1&mute=1&controls=0&showinfo=0&rel=0{{ loop_param }}"
-          allow="autoplay; encrypted-media"
-          allowfullscreen
-          title="{{ video_alt | escape }}"
-        ></iframe>
-      {%- else -%}
-        {%- liquid
-          assign loop_param = ''
-          if section.settings.enable_video_looping
-            assign loop_param = '&loop=1'
-          endif
-        -%}
-        <iframe
-          src="https://player.vimeo.com/video/{{ video_id }}?autoplay=1&muted=1&controls=0&background=1{{ loop_param }}"
-          allow="autoplay; encrypted-media"
-          allowfullscreen
-          title="{{ video_alt | escape }}"
-        ></iframe>
-      {%- endif -%}
-    {%- elsif section.settings.cover_image != blank -%}
-      {%- liquid
-        assign cover_height = section.settings.cover_image.width | divided_by: section.settings.cover_image.aspect_ratio | round
-      -%}
-      {{
-        section.settings.cover_image
-        | image_url: width: 3840
-        | image_tag: sizes: '100vw', widths: '375, 750, 1100, 1500, 1780, 2000, 3000, 3840', height: cover_height
-      }}
-    {%- else -%}
-      {{ 'hero-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
-    {%- endif -%}
-
-    {%- if section.settings.show_image_on_mobile and section.settings.cover_image != blank -%}
-      <div class="video-banner__mobile-image">
+  <div
+    id="Banner-{{ section.id }}"
+    class="banner video-banner banner--content-align-{{ section.settings.desktop_content_alignment }} banner--content-align-mobile-{{ section.settings.mobile_content_alignment }} banner--{{ section.settings.video_height }}{% if section.settings.show_text_below %} banner--mobile-bottom{% endif %}{% if section.settings.show_text_box == false %} banner--desktop-transparent{% endif %}{% if section.settings.show_image_on_mobile and section.settings.cover_image != blank %} video-banner--mobile-image{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+  >
+    <div class="banner__media video-banner__media media{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}">
+      {%- if section.settings.video != blank -%}
+        {{
+          section.settings.video
+          | video_tag:
+            image_size: '1920x',
+            autoplay: true,
+            loop: section.settings.enable_video_looping,
+            controls: false,
+            muted: true,
+            playsinline: true
+        }}
+      {%- elsif section.settings.video_url != blank -%}
+        {%- if section.settings.video_url.type == 'youtube' -%}
+          {%- liquid
+            assign loop_param = ''
+            if section.settings.enable_video_looping
+              assign loop_param = '&loop=1&playlist=' | append: video_id
+            endif
+          -%}
+          <iframe
+            src="https://www.youtube.com/embed/{{ video_id }}?enablejsapi=1&autoplay=1&mute=1&controls=0&showinfo=0&rel=0{{ loop_param }}"
+            class="js-youtube"
+            allow="autoplay; encrypted-media"
+            allowfullscreen
+            title="{{ video_alt | escape }}"
+          ></iframe>
+        {%- else -%}
+          {%- liquid
+            assign loop_param = ''
+            if section.settings.enable_video_looping
+              assign loop_param = '&loop=1'
+            endif
+          -%}
+          <iframe
+            src="https://player.vimeo.com/video/{{ video_id }}?autoplay=1&muted=1&controls=0&background=1{{ loop_param }}"
+            class="js-vimeo"
+            allow="autoplay; encrypted-media"
+            allowfullscreen
+            title="{{ video_alt | escape }}"
+          ></iframe>
+        {%- endif -%}
+      {%- elsif section.settings.cover_image != blank -%}
         {%- liquid
           assign cover_height = section.settings.cover_image.width | divided_by: section.settings.cover_image.aspect_ratio | round
         -%}
         {{
           section.settings.cover_image
-          | image_url: width: 1500
-          | image_tag: sizes: '100vw', widths: '375, 550, 750, 1100, 1500', height: cover_height
+          | image_url: width: 3840
+          | image_tag: sizes: '100vw', widths: '375, 750, 1100, 1500, 1780, 2000, 3000, 3840', height: cover_height
         }}
+      {%- else -%}
+        {{ 'hero-apparel-1' | placeholder_svg_tag: 'placeholder-svg' }}
+      {%- endif -%}
+
+      {%- if section.settings.show_image_on_mobile and section.settings.cover_image != blank -%}
+        <div class="video-banner__mobile-image">
+          {%- liquid
+            assign cover_height = section.settings.cover_image.width | divided_by: section.settings.cover_image.aspect_ratio | round
+          -%}
+          {{
+            section.settings.cover_image
+            | image_url: width: 1500
+            | image_tag: sizes: '100vw', widths: '375, 550, 750, 1100, 1500', height: cover_height
+          }}
+        </div>
+      {%- endif -%}
+    </div>
+
+    <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
+      <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient">
+        {%- for block in section.blocks -%}
+          {%- case block.type -%}
+            {%- when 'heading' -%}
+              <h2
+                class="banner__heading inline-richtext {{ block.settings.heading_size }}"
+                {{ block.shopify_attributes }}
+              >
+                {{ block.settings.heading }}
+              </h2>
+            {%- when 'text' -%}
+              <div class="banner__text rte {{ block.settings.text_style }}" {{ block.shopify_attributes }}>
+                <p>{{ block.settings.text }}</p>
+              </div>
+            {%- when 'buttons' -%}
+              <div
+                class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_label_2 != blank %} banner__buttons--multiple{% endif %}"
+                {{ block.shopify_attributes }}
+              >
+                {%- if block.settings.button_label_1 != blank -%}
+                  <a
+                    {% if block.settings.button_link_1 == blank %}
+                      role="link" aria-disabled="true"
+                    {% else %}
+                      href="{{ block.settings.button_link_1 }}"
+                    {% endif %}
+                    class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"
+                  >
+                    {{- block.settings.button_label_1 | escape -}}
+                  </a>
+                {%- endif -%}
+                {%- if block.settings.button_label_2 != blank -%}
+                  <a
+                    {% if block.settings.button_link_2 == blank %}
+                      role="link" aria-disabled="true"
+                    {% else %}
+                      href="{{ block.settings.button_link_2 }}"
+                    {% endif %}
+                    class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"
+                  >
+                    {{- block.settings.button_label_2 | escape -}}
+                  </a>
+                {%- endif -%}
+              </div>
+          {%- endcase -%}
+        {%- endfor -%}
       </div>
+    </div>
+
+    {%- if has_video and section.settings.show_play_pause -%}
+      <button
+        type="button"
+        class="video-banner__play-pause no-js-hidden"
+        aria-label="Pause video"
+      >
+        <span class="video-banner__pause-icon">
+          <span class="svg-wrapper">
+            {{- 'icon-pause.svg' | inline_asset_content -}}
+          </span>
+        </span>
+        <span class="video-banner__play-icon" hidden>
+          <span class="svg-wrapper">
+            {{- 'icon-play.svg' | inline_asset_content -}}
+          </span>
+        </span>
+      </button>
     {%- endif -%}
   </div>
+</video-banner-component>
 
-  <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
-    <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient">
-      {%- for block in section.blocks -%}
-        {%- case block.type -%}
-          {%- when 'heading' -%}
-            <h2
-              class="banner__heading inline-richtext {{ block.settings.heading_size }}"
-              {{ block.shopify_attributes }}
-            >
-              {{ block.settings.heading }}
-            </h2>
-          {%- when 'text' -%}
-            <div class="banner__text rte {{ block.settings.text_style }}" {{ block.shopify_attributes }}>
-              <p>{{ block.settings.text }}</p>
-            </div>
-          {%- when 'buttons' -%}
-            <div
-              class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_label_2 != blank %} banner__buttons--multiple{% endif %}"
-              {{ block.shopify_attributes }}
-            >
-              {%- if block.settings.button_label_1 != blank -%}
-                <a
-                  {% if block.settings.button_link_1 == blank %}
-                    role="link" aria-disabled="true"
-                  {% else %}
-                    href="{{ block.settings.button_link_1 }}"
-                  {% endif %}
-                  class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"
-                >
-                  {{- block.settings.button_label_1 | escape -}}
-                </a>
-              {%- endif -%}
-              {%- if block.settings.button_label_2 != blank -%}
-                <a
-                  {% if block.settings.button_link_2 == blank %}
-                    role="link" aria-disabled="true"
-                  {% else %}
-                    href="{{ block.settings.button_link_2 }}"
-                  {% endif %}
-                  class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"
-                >
-                  {{- block.settings.button_label_2 | escape -}}
-                </a>
-              {%- endif -%}
-            </div>
-        {%- endcase -%}
-      {%- endfor -%}
-    </div>
-  </div>
-</div>
+<script src="{{ 'video-banner.js' | asset_url }}" defer="defer"></script>
 
 {% schema %}
 {
@@ -208,6 +240,24 @@
       ],
       "default": "medium",
       "label": "Height"
+    },
+    {
+      "type": "header",
+      "content": "Playback"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_play_pause",
+      "label": "Show play/pause button",
+      "info": "Displays a button so visitors can pause and resume the video.",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "pause_offscreen",
+      "label": "Pause video when not visible",
+      "info": "Automatically pauses the video when scrolled out of view to save resources.",
+      "default": true
     },
     {
       "type": "header",


### PR DESCRIPTION
## Summary
This PR introduces a new video banner section that allows merchants to display full-width video backgrounds with customizable overlay content. The section supports both Shopify-hosted videos and embedded YouTube/Vimeo URLs, with a fallback cover image option.

## Key Changes
- **New section template** (`sections/video-banner.liquid`): Complete video banner implementation with support for:
  - Shopify-hosted video uploads
  - YouTube and Vimeo URL embedding with autoplay, muting, and looping controls
  - Cover image fallback when no video is set
  - Mobile-specific cover image display option for performance optimization
  - Customizable content positioning (9 positions) and alignment
  - Configurable overlay opacity
  - Three height options (small, medium, large)
  - Editable content blocks: heading, text, and dual buttons with styling options
  - Color scheme support and animation triggers

- **New stylesheet** (`assets/section-video-banner.css`): Video-specific styling including:
  - Absolute positioning for video/iframe elements with full coverage
  - Mobile fallback image display with conditional visibility
  - Responsive behavior to show cover image instead of video on mobile devices

## Implementation Details
- Reuses layout styles from `section-image-banner.css` for consistency
- Supports dynamic video looping parameters for both YouTube and Vimeo
- Includes accessibility features (alt text, ARIA attributes for disabled buttons)
- Implements scroll-triggered animations when enabled in theme settings
- Mobile optimization through optional cover image replacement to reduce bandwidth usage
- Comprehensive schema configuration with preset blocks for quick setup

https://claude.ai/code/session_01N1h6nWNFecsxH1c6Xy9PoJ