### PR TITLE
Add transparent header with glass morphism on scroll

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1118,6 +1118,10 @@
           "label": "Transparent header text color",
           "info": "Color of menu items and icons when the header is transparent. Use white for dark backgrounds."
         },
+        "transparent_header_opacity": {
+          "label": "Sticky header background opacity",
+          "info": "Background opacity when the header becomes sticky on scroll. Lower values are more transparent."
+        },
         "header__1": {
           "content": "Color"
         },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1114,6 +1114,10 @@
           "label": "Transparent header",
           "info": "Header background becomes transparent, overlaying the content below. Works best with a sticky header enabled."
         },
+        "transparent_text_color": {
+          "label": "Transparent header text color",
+          "info": "Color of menu items and icons when the header is transparent. Use white for dark backgrounds."
+        },
         "header__1": {
           "content": "Color"
         },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1110,6 +1110,10 @@
         "show_line_separator": {
           "label": "Separator line"
         },
+        "enable_transparent_header": {
+          "label": "Transparent header",
+          "info": "Header background becomes transparent, overlaying the content below. Works best with a sticky header enabled."
+        },
         "header__1": {
           "content": "Color"
         },

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -98,6 +98,34 @@
       padding-bottom: {{ section.settings.padding_bottom }}px;
     }
   }
+
+  {%- if section.settings.enable_transparent_header -%}
+    .section-header {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 3;
+    }
+
+    .header-wrapper {
+      background-color: transparent;
+      transition: background-color 0.15s ease-out;
+    }
+
+    .header-wrapper--border-bottom {
+      border-bottom-color: transparent;
+      transition: border-bottom-color 0.15s ease-out;
+    }
+
+    .scrolled-past-header .header-wrapper {
+      background-color: rgb(var(--color-background));
+    }
+
+    .scrolled-past-header .header-wrapper--border-bottom {
+      border-bottom-color: rgba(var(--color-foreground), 0.08);
+    }
+  {%- endif -%}
 {%- endstyle -%}
 
 <script src="{{ 'cart-notification.js' | asset_url }}" defer="defer"></script>
@@ -568,6 +596,13 @@
       "id": "show_line_separator",
       "default": true,
       "label": "t:sections.header.settings.show_line_separator.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_transparent_header",
+      "default": false,
+      "label": "t:sections.header.settings.enable_transparent_header.label",
+      "info": "t:sections.header.settings.enable_transparent_header.info"
     },
     {
       "type": "header",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -102,20 +102,25 @@
   {%- if section.settings.enable_transparent_header -%}
     {%- assign transparent_opacity = section.settings.transparent_header_opacity | divided_by: 100.0 -%}
 
-    .shopify-section-group-header-group {
-      position: absolute;
+    /*
+      Shopify merges the section-group wrapper and section wrapper into
+      one element when the group has a single section. This element gets
+      classes from both (.shopify-section-group-header-group AND
+      .section-header AND .shopify-section-header-sticky). We use a
+      3-class compound selector to beat base.css's sticky rule (0,1,0)
+      and the z-index rule (0,2,0) which load after inline styles.
+    */
+    .shopify-section.shopify-section-group-header-group.section-header {
+      position: absolute !important;
       top: 0;
       left: 0;
       right: 0;
       z-index: 1001;
-    }
-
-    .section-header {
       margin-bottom: 0;
     }
 
-    .section-header.shopify-section-header-sticky.scrolled-past-header {
-      position: sticky;
+    .shopify-section.shopify-section-group-header-group.section-header.scrolled-past-header {
+      position: sticky !important;
       top: 0;
     }
 

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -101,33 +101,31 @@
 
   {%- if section.settings.enable_transparent_header -%}
     .section-header {
-      position: absolute !important;
+      position: absolute;
       left: 0;
       right: 0;
       z-index: 1001;
-      margin-bottom: 0 !important;
+      margin-bottom: 0;
     }
 
     .section-header.shopify-section-header-sticky {
-      position: sticky !important;
+      position: sticky;
     }
 
-    .header-wrapper {
-      background-color: transparent !important;
-      background-image: none !important;
-      transition: background-color 0.15s ease-out, background-image 0.15s ease-out, border-bottom-color 0.15s ease-out;
+    .header-wrapper--transparent {
+      background-color: transparent;
+      transition: background-color 0.15s ease-out, border-bottom-color 0.15s ease-out;
     }
 
-    .header-wrapper--border-bottom {
+    .header-wrapper--transparent.header-wrapper--border-bottom {
       border-bottom-color: transparent;
     }
 
-    .scrolled-past-header .header-wrapper {
-      background-color: rgb(var(--color-background)) !important;
-      background-image: var(--gradient-background) !important;
+    .scrolled-past-header .header-wrapper--transparent {
+      background-color: rgb(var(--color-background));
     }
 
-    .scrolled-past-header .header-wrapper--border-bottom {
+    .scrolled-past-header .header-wrapper--transparent.header-wrapper--border-bottom {
       border-bottom-color: rgba(var(--color-foreground), 0.08);
     }
   {%- endif -%}
@@ -160,7 +158,7 @@
   {% if header_tag == 'sticky-header' %}
     data-sticky-type="{{ effective_sticky_type }}"
   {% endif %}
-  class="header-wrapper color-{{ section.settings.color_scheme }} gradient{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %}"
+  class="header-wrapper color-{{ section.settings.color_scheme }}{% unless section.settings.enable_transparent_header %} gradient{% endunless %}{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %}{% if section.settings.enable_transparent_header %} header-wrapper--transparent{% endif %}"
 >
   {%- liquid
     assign social_links = false

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -102,24 +102,28 @@
   {%- if section.settings.enable_transparent_header -%}
     .section-header {
       position: absolute;
-      top: 0;
       left: 0;
       right: 0;
-      z-index: 3;
+      z-index: 10;
+    }
+
+    .section-header.shopify-section-header-sticky {
+      position: sticky;
     }
 
     .header-wrapper {
       background-color: transparent;
-      transition: background-color 0.15s ease-out;
+      background-image: none;
+      transition: background-color 0.15s ease-out, background-image 0.15s ease-out, border-bottom-color 0.15s ease-out;
     }
 
     .header-wrapper--border-bottom {
       border-bottom-color: transparent;
-      transition: border-bottom-color 0.15s ease-out;
     }
 
     .scrolled-past-header .header-wrapper {
       background-color: rgb(var(--color-background));
+      background-image: var(--gradient-background);
     }
 
     .scrolled-past-header .header-wrapper--border-bottom {
@@ -140,15 +144,20 @@
 
 {% liquid
   assign header_tag = 'div'
+  assign effective_sticky_type = section.settings.sticky_header_type
 
-  if section.settings.sticky_header_type != 'none'
+  if section.settings.enable_transparent_header and effective_sticky_type == 'none'
+    assign effective_sticky_type = 'on-scroll-up'
+  endif
+
+  if effective_sticky_type != 'none'
     assign header_tag = 'sticky-header'
   endif
 %}
 
 <{{ header_tag }}
   {% if header_tag == 'sticky-header' %}
-    data-sticky-type="{{ section.settings.sticky_header_type }}"
+    data-sticky-type="{{ effective_sticky_type }}"
   {% endif %}
   class="header-wrapper color-{{ section.settings.color_scheme }} gradient{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %}"
 >

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -112,20 +112,52 @@
       position: sticky;
     }
 
-    .header-wrapper--transparent {
+    .header-wrapper.header-wrapper--transparent {
       background-color: transparent;
-      transition: background-color 0.15s ease-out, border-bottom-color 0.15s ease-out;
+      background-image: none;
+      transition: background-color 0.3s ease, background-image 0.3s ease, border-bottom-color 0.3s ease;
     }
 
-    .header-wrapper--transparent.header-wrapper--border-bottom {
+    .header-wrapper.header-wrapper--transparent .header__heading-link,
+    .header-wrapper.header-wrapper--transparent .header__menu-item,
+    .header-wrapper.header-wrapper--transparent .list-menu__item,
+    .header-wrapper.header-wrapper--transparent .header__icon,
+    .header-wrapper.header-wrapper--transparent .header__icon::before,
+    .header-wrapper.header-wrapper--transparent .localization-form__select,
+    .header-wrapper.header-wrapper--transparent summary {
+      color: {{ section.settings.transparent_text_color }};
+    }
+
+    .header-wrapper.header-wrapper--transparent .header__icon svg path,
+    .header-wrapper.header-wrapper--transparent summary svg path {
+      fill: {{ section.settings.transparent_text_color }};
+      stroke: {{ section.settings.transparent_text_color }};
+    }
+
+    .header-wrapper.header-wrapper--transparent.header-wrapper--border-bottom {
       border-bottom-color: transparent;
     }
 
-    .scrolled-past-header .header-wrapper--transparent {
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent {
       background-color: rgb(var(--color-background));
     }
 
-    .scrolled-past-header .header-wrapper--transparent.header-wrapper--border-bottom {
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__heading-link,
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__menu-item,
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent .list-menu__item,
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__icon,
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent .localization-form__select,
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent summary {
+      color: rgba(var(--color-foreground), 0.75);
+    }
+
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__icon svg path,
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent summary svg path {
+      fill: rgb(var(--color-foreground));
+      stroke: rgb(var(--color-foreground));
+    }
+
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent.header-wrapper--border-bottom {
       border-bottom-color: rgba(var(--color-foreground), 0.08);
     }
   {%- endif -%}
@@ -611,6 +643,13 @@
       "default": false,
       "label": "t:sections.header.settings.enable_transparent_header.label",
       "info": "t:sections.header.settings.enable_transparent_header.info"
+    },
+    {
+      "type": "color",
+      "id": "transparent_text_color",
+      "default": "#ffffff",
+      "label": "t:sections.header.settings.transparent_text_color.label",
+      "info": "t:sections.header.settings.transparent_text_color.info"
     },
     {
       "type": "header",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -100,6 +100,8 @@
   }
 
   {%- if section.settings.enable_transparent_header -%}
+    {%- assign transparent_opacity = section.settings.transparent_header_opacity | divided_by: 100.0 -%}
+
     .section-header {
       position: absolute;
       left: 0;
@@ -108,7 +110,7 @@
       margin-bottom: 0;
     }
 
-    .section-header.shopify-section-header-sticky {
+    .section-header.shopify-section-header-sticky.scrolled-past-header {
       position: sticky;
     }
 
@@ -140,21 +142,38 @@
       border-bottom-color: transparent;
     }
 
-    /* Glass morphism: semi-transparent background appears when scrolling up after scrolling past header */
+    /* Feathered bottom edge */
+    .header-wrapper.header-wrapper--transparent::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 40px;
+      background: linear-gradient(to bottom, rgba(var(--color-background), 0.12), transparent);
+      transform: translateY(100%);
+      pointer-events: none;
+      transition: opacity 0.35s ease-out;
+    }
+
+    /* Glass morphism: semi-transparent background when scrolled past header */
     .scrolled-past-header .header-wrapper.header-wrapper--transparent {
-      background-color: rgba(var(--color-background), 0.72);
+      background-color: rgba(var(--color-background), {{ transparent_opacity }});
       backdrop-filter: blur(12px) saturate(180%);
       -webkit-backdrop-filter: blur(12px) saturate(180%);
+    }
+
+    .scrolled-past-header .header-wrapper.header-wrapper--transparent::after {
+      background: linear-gradient(to bottom, rgba(var(--color-background), {{ transparent_opacity | times: 0.4 }}), transparent);
     }
 
     .scrolled-past-header .header-wrapper.header-wrapper--transparent.header-wrapper--border-bottom {
       border-bottom-color: rgba(var(--color-foreground), 0.08);
     }
 
-    /* Fallback for browsers without backdrop-filter support (e.g. older Firefox) */
     @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
       .scrolled-past-header .header-wrapper.header-wrapper--transparent {
-        background-color: rgba(var(--color-background), 0.92);
+        background-color: rgba(var(--color-background), {{ transparent_opacity | plus: 0.2 | at_most: 1.0 }});
       }
     }
   {%- endif -%}
@@ -647,6 +666,17 @@
       "default": "#ffffff",
       "label": "t:sections.header.settings.transparent_text_color.label",
       "info": "t:sections.header.settings.transparent_text_color.info"
+    },
+    {
+      "type": "range",
+      "id": "transparent_header_opacity",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "unit": "%",
+      "default": 70,
+      "label": "t:sections.header.settings.transparent_header_opacity.label",
+      "info": "t:sections.header.settings.transparent_header_opacity.info"
     },
     {
       "type": "header",

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -102,16 +102,21 @@
   {%- if section.settings.enable_transparent_header -%}
     {%- assign transparent_opacity = section.settings.transparent_header_opacity | divided_by: 100.0 -%}
 
-    .section-header {
+    .shopify-section-group-header-group {
       position: absolute;
+      top: 0;
       left: 0;
       right: 0;
       z-index: 1001;
+    }
+
+    .section-header {
       margin-bottom: 0;
     }
 
     .section-header.shopify-section-header-sticky.scrolled-past-header {
       position: sticky;
+      top: 0;
     }
 
     .header-wrapper.header-wrapper--transparent {

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -115,7 +115,9 @@
     .header-wrapper.header-wrapper--transparent {
       background-color: transparent;
       background-image: none;
-      transition: background-color 0.3s ease, background-image 0.3s ease, border-bottom-color 0.3s ease;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      transition: background-color 0.35s ease-out, backdrop-filter 0.35s ease-out, -webkit-backdrop-filter 0.35s ease-out, border-bottom-color 0.35s ease-out;
     }
 
     .header-wrapper.header-wrapper--transparent .header__heading-link,
@@ -138,27 +140,22 @@
       border-bottom-color: transparent;
     }
 
+    /* Glass morphism: semi-transparent background appears when scrolling up after scrolling past header */
     .scrolled-past-header .header-wrapper.header-wrapper--transparent {
-      background-color: rgb(var(--color-background));
-    }
-
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__heading-link,
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__menu-item,
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent .list-menu__item,
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__icon,
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent .localization-form__select,
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent summary {
-      color: rgba(var(--color-foreground), 0.75);
-    }
-
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent .header__icon svg path,
-    .scrolled-past-header .header-wrapper.header-wrapper--transparent summary svg path {
-      fill: rgb(var(--color-foreground));
-      stroke: rgb(var(--color-foreground));
+      background-color: rgba(var(--color-background), 0.72);
+      backdrop-filter: blur(12px) saturate(180%);
+      -webkit-backdrop-filter: blur(12px) saturate(180%);
     }
 
     .scrolled-past-header .header-wrapper.header-wrapper--transparent.header-wrapper--border-bottom {
       border-bottom-color: rgba(var(--color-foreground), 0.08);
+    }
+
+    /* Fallback for browsers without backdrop-filter support (e.g. older Firefox) */
+    @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+      .scrolled-past-header .header-wrapper.header-wrapper--transparent {
+        background-color: rgba(var(--color-background), 0.92);
+      }
     }
   {%- endif -%}
 {%- endstyle -%}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -101,19 +101,20 @@
 
   {%- if section.settings.enable_transparent_header -%}
     .section-header {
-      position: absolute;
+      position: absolute !important;
       left: 0;
       right: 0;
-      z-index: 10;
+      z-index: 1001;
+      margin-bottom: 0 !important;
     }
 
     .section-header.shopify-section-header-sticky {
-      position: sticky;
+      position: sticky !important;
     }
 
     .header-wrapper {
-      background-color: transparent;
-      background-image: none;
+      background-color: transparent !important;
+      background-image: none !important;
       transition: background-color 0.15s ease-out, background-image 0.15s ease-out, border-bottom-color 0.15s ease-out;
     }
 
@@ -122,8 +123,8 @@
     }
 
     .scrolled-past-header .header-wrapper {
-      background-color: rgb(var(--color-background));
-      background-image: var(--gradient-background);
+      background-color: rgb(var(--color-background)) !important;
+      background-image: var(--gradient-background) !important;
     }
 
     .scrolled-past-header .header-wrapper--border-bottom {


### PR DESCRIPTION
## Summary

- Adds a transparent header mode that overlays page content (hero banners, videos) with the header floating on top
- On scroll, the header reveals as a frosted-glass sticky bar with configurable opacity and backdrop blur
- At the top of the page, the header is fully transparent with content visible behind it
- Includes a feathered bottom edge that fades the header smoothly into the content below

## New Settings (Header section)

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| **Transparent header** | Checkbox | Off | Enable transparent overlay mode |
| **Transparent header text color** | Color | `#ffffff` | Menu/icon color when transparent (white for dark heroes) |
| **Sticky header background opacity** | Range 0-100% | 70% | Glass background opacity on scroll |

## Behavior

| State | Background | Position |
|-------|-----------|----------|
| Top of page | Fully transparent | `absolute` (content behind header) |
| Scrolling down | Header hides (slides up) | — |
| Scrolling up | Semi-transparent + blur (glass morphism) | `sticky` |
| Back to top | Returns to fully transparent | `absolute` |

## Files Changed

- `sections/header.liquid` — Conditional CSS, schema settings, class logic
- `locales/en.default.schema.json` — Translation keys for new settings

## Test Plan

- [ ] Enable "Transparent header" in Header section settings
- [ ] Set text color to white, opacity to ~70%
- [ ] Verify hero/video banner is visible behind the header at page top
- [ ] Scroll down — header should slide out of view
- [ ] Scroll up — header reveals with frosted-glass background
- [ ] Scroll all the way back to top — header returns to fully transparent
- [ ] Check feathered bottom edge fades header into content
- [ ] Test with different sticky modes (on-scroll-up, always)
- [ ] Test on mobile and tablet viewports
- [ ] Test dropdown/mega menus still function

https://claude.ai/code/session_01USK87QuSEuWW3tSYqMr8x2