### PR TITLE
Add OmniTask neon and glitch effects to theme

### DIFF
--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -41,6 +41,14 @@
      the glitch slices conform to whichever button color is in play. */
   --ofx-glitch-color-1: 0, 210, 255;
   --ofx-glitch-color-2: 255, 42, 160;
+
+  /* Multipliers + animation timings — themeable via Theme Settings →
+     Neon & glitch effects → Neon glow strength. Theme.liquid emits
+     overrides at :root when merchants change the values. */
+  --ofx-glow-intensity: 1;
+  --ofx-text-glow-intensity: 1;
+  --ofx-pulse-duration: 2s;
+  --ofx-flicker-duration: 3s;
 }
 
 /* =============================================================
@@ -159,15 +167,15 @@
   border: 2px solid rgb(var(--ofx-neon-rgb));
   color: rgb(var(--ofx-neon-rgb));
   text-shadow:
-    0 0 6px rgba(var(--ofx-neon-rgb), 0.85),
-    0 0 14px rgba(var(--ofx-neon-rgb), 0.45);
+    0 0 calc(6px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 calc(14px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45);
   /* Same symmetric inward + outward halo as .button.button--neon. */
   box-shadow:
-    0 0 8px rgba(var(--ofx-neon-rgb), 0.45),
-    0 0 18px rgba(var(--ofx-neon-rgb), 0.28),
-    0 0 36px rgba(var(--ofx-neon-rgb), 0.14),
-    inset 0 0 8px rgba(var(--ofx-neon-rgb), 0.3),
-    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.14);
+    0 0 calc(8px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.28),
+    0 0 calc(36px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.14),
+    inset 0 0 calc(8px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.14);
   transition: all 0.25s ease;
   overflow: hidden;
 }
@@ -197,11 +205,11 @@
     rgba(var(--ofx-neon-rgb), 0.22)
   );
   box-shadow:
-    0 0 14px rgba(var(--ofx-neon-rgb), 0.7),
-    0 0 28px rgba(var(--ofx-neon-rgb), 0.45),
-    0 0 56px rgba(var(--ofx-neon-rgb), 0.22),
-    inset 0 0 14px rgba(var(--ofx-neon-rgb), 0.45),
-    inset 0 0 26px rgba(var(--ofx-neon-rgb), 0.22);
+    0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.7),
+    0 0 calc(28px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 calc(56px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22),
+    inset 0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
+    inset 0 0 calc(26px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22);
   transform: translateY(-1px);
 }
 
@@ -218,14 +226,14 @@
   background-image: none;
   color: #050810;
   text-shadow:
-    0 0 6px rgba(255, 255, 255, 0.85),
-    0 0 14px rgba(255, 255, 255, 0.45);
+    0 0 calc(6px * var(--ofx-text-glow-intensity)) rgba(255, 255, 255, 0.85),
+    0 0 calc(14px * var(--ofx-text-glow-intensity)) rgba(255, 255, 255, 0.45);
   box-shadow:
-    0 0 10px rgba(var(--ofx-neon-rgb), 0.55),
-    0 0 24px rgba(var(--ofx-neon-rgb), 0.35),
-    0 0 48px rgba(var(--ofx-neon-rgb), 0.18),
-    inset 0 0 6px rgba(255, 255, 255, 0.22),
-    inset 0 0 18px rgba(255, 255, 255, 0.08);
+    0 0 calc(10px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 calc(24px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.35),
+    0 0 calc(48px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.18),
+    inset 0 0 calc(6px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.22),
+    inset 0 0 calc(18px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.08);
 }
 
 .ofx-neon-button-fill:hover {
@@ -234,11 +242,11 @@
   color: #050810;
   transform: translateY(-1px);
   box-shadow:
-    0 0 16px rgba(var(--ofx-neon-rgb), 0.85),
-    0 0 36px rgba(var(--ofx-neon-rgb), 0.55),
-    0 0 70px rgba(var(--ofx-neon-rgb), 0.28),
-    inset 0 0 10px rgba(255, 255, 255, 0.35),
-    inset 0 0 22px rgba(255, 255, 255, 0.15);
+    0 0 calc(16px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 calc(36px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 calc(70px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.28),
+    inset 0 0 calc(10px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.35),
+    inset 0 0 calc(22px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.15);
 }
 
 /* Color variants — apply alongside .ofx-neon-button[-fill] */
@@ -293,19 +301,19 @@
   ) !important;
   color: rgb(var(--ofx-neon-rgb)) !important;
   text-shadow:
-    0 0 6px rgba(var(--ofx-neon-rgb), 0.85),
-    0 0 14px rgba(var(--ofx-neon-rgb), 0.45);
+    0 0 calc(6px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 calc(14px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45);
   /* Symmetric glow — three outer halos at increasing radius for a
      soft falloff outward, plus two inset halos so the glow also
      pulses inward. The 0/0 offset on every shadow keeps the halo
      centered, so it spreads evenly on all four sides instead of
      drifting toward Dawn's directional --buttons-shadow-* offsets. */
   box-shadow:
-    0 0 8px rgba(var(--ofx-neon-rgb), 0.45),
-    0 0 18px rgba(var(--ofx-neon-rgb), 0.28),
-    0 0 36px rgba(var(--ofx-neon-rgb), 0.14),
-    inset 0 0 8px rgba(var(--ofx-neon-rgb), 0.3),
-    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.14);
+    0 0 calc(8px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.28),
+    0 0 calc(36px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.14),
+    inset 0 0 calc(8px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.14);
   transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
   overflow: hidden;
 }
@@ -348,11 +356,11 @@
      punched up — outer halos brighter + reaching further, inner
      halos thicker. */
   box-shadow:
-    0 0 14px rgba(var(--ofx-neon-rgb), 0.7),
-    0 0 28px rgba(var(--ofx-neon-rgb), 0.45),
-    0 0 56px rgba(var(--ofx-neon-rgb), 0.22),
-    inset 0 0 14px rgba(var(--ofx-neon-rgb), 0.45),
-    inset 0 0 26px rgba(var(--ofx-neon-rgb), 0.22);
+    0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.7),
+    0 0 calc(28px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 calc(56px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22),
+    inset 0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
+    inset 0 0 calc(26px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22);
   transform: translateY(-1px);
 }
 
@@ -373,18 +381,18 @@
   background-color: rgba(var(--ofx-neon-rgb), 0.85) !important;
   color: rgb(var(--ofx-button-label-rgb)) !important;
   text-shadow:
-    0 0 6px rgba(255, 255, 255, 0.85),
-    0 0 14px rgba(255, 255, 255, 0.45);
+    0 0 calc(6px * var(--ofx-text-glow-intensity)) rgba(255, 255, 255, 0.85),
+    0 0 calc(14px * var(--ofx-text-glow-intensity)) rgba(255, 255, 255, 0.45);
   /* Symmetric outward halo at three radii + a white inset rim so the
      glow reads as both inward and outward, not biased to one side
      by Dawn's --buttons-shadow-* offsets (which are suppressed on
      the ::before pseudo-element). */
   box-shadow:
-    0 0 10px rgba(var(--ofx-neon-rgb), 0.55),
-    0 0 24px rgba(var(--ofx-neon-rgb), 0.35),
-    0 0 48px rgba(var(--ofx-neon-rgb), 0.18),
-    inset 0 0 6px rgba(255, 255, 255, 0.22),
-    inset 0 0 18px rgba(255, 255, 255, 0.08);
+    0 0 calc(10px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 calc(24px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.35),
+    0 0 calc(48px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.18),
+    inset 0 0 calc(6px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.22),
+    inset 0 0 calc(18px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.08);
   transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
   overflow: hidden;
 }
@@ -404,11 +412,11 @@
   background-color: rgba(var(--ofx-neon-rgb), 1) !important;
   color: rgb(var(--ofx-button-label-rgb)) !important;
   box-shadow:
-    0 0 16px rgba(var(--ofx-neon-rgb), 0.85),
-    0 0 36px rgba(var(--ofx-neon-rgb), 0.55),
-    0 0 70px rgba(var(--ofx-neon-rgb), 0.28),
-    inset 0 0 10px rgba(255, 255, 255, 0.35),
-    inset 0 0 22px rgba(255, 255, 255, 0.15);
+    0 0 calc(16px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 calc(36px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 calc(70px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.28),
+    inset 0 0 calc(10px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.35),
+    inset 0 0 calc(22px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.15);
   transform: translateY(-1px);
 }
 
@@ -431,64 +439,64 @@
    Pulsing glow + flickering text utilities
    ============================================================= */
 .cyber-pulse {
-  animation: ofx-cyber-pulse 2s ease-in-out infinite;
+  animation: ofx-cyber-pulse var(--ofx-pulse-duration) ease-in-out infinite;
 }
 
 @keyframes ofx-cyber-pulse {
   0%, 100% {
     box-shadow:
-      0 0 15px rgba(var(--ofx-neon-rgb), 0.3),
-      inset 0 0 15px rgba(var(--ofx-neon-rgb), 0.1);
+      0 0 calc(15px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.3),
+      inset 0 0 calc(15px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.1);
   }
   50% {
     box-shadow:
-      0 0 25px rgba(var(--ofx-neon-rgb), 0.5),
-      inset 0 0 25px rgba(var(--ofx-neon-rgb), 0.2);
+      0 0 calc(25px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.5),
+      inset 0 0 calc(25px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.2);
   }
 }
 
 .cyber-border-glow {
   border: 1px solid rgba(var(--ofx-neon-rgb), 0.4);
   box-shadow:
-    0 0 10px rgba(var(--ofx-neon-rgb), 0.25),
-    inset 0 0 10px rgba(var(--ofx-neon-rgb), 0.08);
+    0 0 calc(10px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.25),
+    inset 0 0 calc(10px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.08);
   transition: all 0.25s ease;
 }
 
 .cyber-border-glow:hover {
   border-color: rgba(var(--ofx-neon-rgb), 0.7);
   box-shadow:
-    0 0 18px rgba(var(--ofx-neon-rgb), 0.5),
-    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.15);
+    0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.5),
+    inset 0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.15);
 }
 
 .text-neon {
   color: rgb(var(--ofx-neon-rgb));
   text-shadow:
-    0 0 5px rgb(var(--ofx-neon-rgb)),
-    0 0 10px rgb(var(--ofx-neon-rgb)),
-    0 0 20px rgb(var(--ofx-neon-rgb)),
-    0 0 40px rgba(var(--ofx-neon-rgb), 0.4);
+    0 0 calc(5px * var(--ofx-text-glow-intensity)) rgb(var(--ofx-neon-rgb)),
+    0 0 calc(10px * var(--ofx-text-glow-intensity)) rgb(var(--ofx-neon-rgb)),
+    0 0 calc(20px * var(--ofx-text-glow-intensity)) rgb(var(--ofx-neon-rgb)),
+    0 0 calc(40px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.4);
 }
 
 .text-neon-flicker {
   color: rgb(var(--ofx-neon-rgb));
   text-shadow:
-    0 0 8px rgba(var(--ofx-neon-rgb), 0.8),
-    0 0 16px rgba(var(--ofx-neon-rgb), 0.5);
-  animation: ofx-text-flicker 3s infinite;
+    0 0 calc(8px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.8),
+    0 0 calc(16px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.5);
+  animation: ofx-text-flicker var(--ofx-flicker-duration) infinite;
 }
 
 @keyframes ofx-text-flicker {
   0%, 100% {
     text-shadow:
-      0 0 8px rgba(var(--ofx-neon-rgb), 0.8),
-      0 0 16px rgba(var(--ofx-neon-rgb), 0.5);
+      0 0 calc(8px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.8),
+      0 0 calc(16px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.5);
   }
   50% {
     text-shadow:
-      0 0 12px rgba(var(--ofx-neon-rgb), 1),
-      0 0 22px rgba(var(--ofx-neon-rgb), 0.7);
+      0 0 calc(12px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 1),
+      0 0 calc(22px * var(--ofx-text-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.7);
   }
 }
 

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -307,15 +307,25 @@
      soft falloff outward, plus two inset halos so the glow also
      pulses inward. The 0/0 offset on every shadow keeps the halo
      centered, so it spreads evenly on all four sides instead of
-     drifting toward Dawn's directional --buttons-shadow-* offsets. */
+     drifting toward Dawn's directional --buttons-shadow-* offsets.
+     !important needed so Dawn's --buttons-shadow-* drop shadow on
+     .button:before doesn't visually compete and so the focus-visible
+     ring inheritance can't wipe the resting glow. */
   box-shadow:
     0 0 calc(8px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
     0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.28),
     0 0 calc(36px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.14),
     inset 0 0 calc(8px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.3),
-    inset 0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.14);
+    inset 0 0 calc(18px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.14) !important;
   transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
   overflow: hidden;
+}
+
+/* Suppress Dawn's directional drop shadow on .button:before — it sits
+   behind the button (z-index: -1) and would peek out one side, breaking
+   the symmetric neon halo. */
+.button.button--neon::before {
+  box-shadow: none !important;
 }
 
 .button.button--neon::after {
@@ -354,14 +364,39 @@
   ) !important;
   /* Same symmetric inward + outward glow as the resting state, just
      punched up — outer halos brighter + reaching further, inner
-     halos thicker. */
+     halos thicker. !important is required so Dawn's
+     .animate--hover-3d-lift / .animate--hover-vertical-lift hover
+     rules (specificity 0,4,1 — higher than ours at 0,3,1) don't
+     wipe the glow with their own box-shadow / transform. */
   box-shadow:
     0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.7),
     0 0 calc(28px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
     0 0 calc(56px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22),
     inset 0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
-    inset 0 0 calc(26px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22);
-  transform: translateY(-1px);
+    inset 0 0 calc(26px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22) !important;
+  transform: translateY(-1px) !important;
+}
+
+/* Keyboard-focus accessibility — preserve the neon halo while still
+   surfacing a clear focus indicator. Dawn's .button:focus-visible
+   (specificity 0,2,1) replaces box-shadow with a high-contrast ring
+   and would erase the neon glow; this rule reasserts the glow via
+   !important and uses outline (which Dawn zeroes) for the a11y ring. */
+.button.button--neon:focus-visible,
+.button.button--neon:focus,
+.button.button--neon-fill:focus-visible,
+.button.button--neon-fill:focus,
+.ofx-neon-button:focus-visible,
+.ofx-neon-button:focus,
+.ofx-neon-button-fill:focus-visible,
+.ofx-neon-button-fill:focus {
+  outline: 2px solid rgb(var(--ofx-neon-rgb));
+  outline-offset: 3px;
+  box-shadow:
+    0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.7),
+    0 0 calc(28px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 calc(56px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.22),
+    inset 0 0 calc(14px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.45) !important;
 }
 
 .button.button--neon:not([disabled]):hover::before {
@@ -416,8 +451,8 @@
     0 0 calc(36px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.55),
     0 0 calc(70px * var(--ofx-glow-intensity)) rgba(var(--ofx-neon-rgb), 0.28),
     inset 0 0 calc(10px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.35),
-    inset 0 0 calc(22px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.15);
-  transform: translateY(-1px);
+    inset 0 0 calc(22px * var(--ofx-glow-intensity)) rgba(255, 255, 255, 0.15) !important;
+  transform: translateY(-1px) !important;
 }
 
 /* Explicit color overrides — apply alongside .button--neon[-fill] to
@@ -911,6 +946,21 @@
 .ofx-neon-button[data-fx-glitch][data-pg-bound]:active,
 .ofx-neon-button-fill[data-fx-glitch][data-pg-bound]:active {
   animation: none;
+}
+
+/* PowerGlitch slice clones — JS deep-clones the button (so the slice
+   tints inherit the live background + border + label color) and stamps
+   data-pg-slice="true" on each clone. Dawn's .button::before draws a
+   directional drop shadow and animates a left-to-right sweep; Dawn's
+   .button::after draws an inner ring. Both are decorative chrome that
+   doesn't belong in a slice band — they cause flicker artifacts and
+   ghost rings that visually break the "shifted band of the live
+   button" illusion. Hiding them on clones is safe because the original
+   button keeps its own pseudo-elements untouched. */
+[data-pg-slice="true"]::before,
+[data-pg-slice="true"]::after {
+  display: none !important;
+  animation: none !important;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -1,0 +1,594 @@
+/* =============================================================
+   OmniFlex Neon & Glitch Effects
+   Ported from OmniTask (src/styles.css) for use in the Dawn-based
+   OmniFlex Shopify theme. Provides:
+     - Neon palette CSS variables (--ofx-cyan, --ofx-purple, etc.)
+     - Outline + fill neon button variants (.button--neon-*)
+     - Standalone OmniTask-style neon buttons (.ofx-neon-button*)
+     - Decode/scramble overlay rules ([data-scramble])
+     - Chromatic-aberration glitch animations on hover & active
+       ([data-fx-glitch], [data-fx-glitch-hover], [data-fx-glitch-click],
+        [data-fx-glitch-box])
+     - Pulsing border glow + flickering text utilities
+   All animations bow out under prefers-reduced-motion: reduce.
+   ============================================================= */
+
+:root {
+  --ofx-cyan: #00d2ff;
+  --ofx-cyan-dark: #0073ff;
+  --ofx-purple: #e040fb;
+  --ofx-magenta: #d500f9;
+  --ofx-pink: #ff1493;
+  --ofx-green: #8ce696;
+  --ofx-yellow: #f0d278;
+  --ofx-orange: #ffaa78;
+  --ofx-blue: #50beff;
+  --ofx-red: #ff788c;
+
+  --ofx-cyan-rgb: 0, 210, 255;
+  --ofx-purple-rgb: 224, 64, 251;
+  --ofx-magenta-rgb: 213, 0, 249;
+  --ofx-pink-rgb: 255, 20, 147;
+  --ofx-green-rgb: 140, 230, 150;
+  --ofx-blue-rgb: 80, 190, 255;
+
+  /* Default neon accent — overridable per-button via --ofx-neon-rgb */
+  --ofx-neon-rgb: var(--ofx-cyan-rgb);
+  --ofx-neon: rgb(var(--ofx-neon-rgb));
+}
+
+/* =============================================================
+   Selection — pick up the active neon color
+   ============================================================= */
+.neon-active ::selection {
+  background: rgba(var(--ofx-neon-rgb), 0.4);
+  color: #ffffff;
+  text-shadow: 0 0 10px rgba(var(--ofx-neon-rgb), 0.5);
+}
+
+/* =============================================================
+   Standalone OmniTask neon buttons (drop-in classes)
+   These do not depend on Dawn's .button base styles — useful for
+   custom liquid blocks or rich text where merchants want a pure
+   OmniTask look.
+   ============================================================= */
+.ofx-neon-button,
+.ofx-neon-button-fill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.2rem 2.4rem;
+  border-radius: 0.8rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  cursor: pointer;
+  background: rgba(var(--ofx-neon-rgb), 0.08);
+  border: 2px solid rgb(var(--ofx-neon-rgb));
+  color: rgb(var(--ofx-neon-rgb));
+  text-shadow: 0 0 10px rgba(var(--ofx-neon-rgb), 0.7);
+  box-shadow:
+    0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
+    0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
+    inset 0 0 12px rgba(var(--ofx-neon-rgb), 0.08);
+  transition: all 0.25s ease;
+  overflow: hidden;
+}
+
+.ofx-neon-button::before,
+.ofx-neon-button-fill::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(var(--ofx-neon-rgb), 0.25),
+    transparent
+  );
+  transition: left 0.5s ease;
+  pointer-events: none;
+}
+
+.ofx-neon-button:hover,
+.ofx-neon-button-fill:hover {
+  background: rgba(var(--ofx-neon-rgb), 0.16);
+  box-shadow:
+    0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
+    0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18);
+  transform: translateY(-1px);
+}
+
+.ofx-neon-button:hover::before,
+.ofx-neon-button-fill:hover::before {
+  left: 100%;
+}
+
+/* Filled variant — neon background, dark text */
+.ofx-neon-button-fill {
+  background: rgba(var(--ofx-neon-rgb), 0.85);
+  color: #050810;
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+  box-shadow:
+    0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
+    0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 8px rgba(255, 255, 255, 0.15);
+}
+
+.ofx-neon-button-fill:hover {
+  background: rgba(var(--ofx-neon-rgb), 1);
+  color: #050810;
+  box-shadow:
+    0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
+    0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
+    inset 0 0 12px rgba(255, 255, 255, 0.25);
+}
+
+/* Color variants — apply alongside .ofx-neon-button[-fill] */
+.ofx-neon--cyan    { --ofx-neon-rgb: var(--ofx-cyan-rgb); }
+.ofx-neon--purple  { --ofx-neon-rgb: var(--ofx-purple-rgb); }
+.ofx-neon--magenta { --ofx-neon-rgb: var(--ofx-magenta-rgb); }
+.ofx-neon--pink    { --ofx-neon-rgb: var(--ofx-pink-rgb); }
+.ofx-neon--green   { --ofx-neon-rgb: var(--ofx-green-rgb); }
+.ofx-neon--blue    { --ofx-neon-rgb: var(--ofx-blue-rgb); }
+
+/* =============================================================
+   Dawn .button neon overlay — applies neon glow to existing
+   theme buttons (.button--primary, .button--secondary). Use
+   alongside .button to get an OmniTask-flavored hover without
+   discarding Dawn's box model.
+   ============================================================= */
+.button.button--neon {
+  position: relative;
+  border: 2px solid rgb(var(--ofx-neon-rgb)) !important;
+  background-color: rgba(var(--ofx-neon-rgb), 0.08) !important;
+  color: rgb(var(--ofx-neon-rgb)) !important;
+  text-shadow: 0 0 10px rgba(var(--ofx-neon-rgb), 0.7);
+  box-shadow:
+    0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
+    0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
+    inset 0 0 12px rgba(var(--ofx-neon-rgb), 0.08);
+  transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
+  overflow: hidden;
+}
+
+.button.button--neon::after {
+  /* Suppress Dawn's interior border ring so the neon outline reads cleanly */
+  box-shadow: none !important;
+}
+
+.button.button--neon::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(var(--ofx-neon-rgb), 0.25),
+    transparent
+  );
+  transition: left 0.5s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.button.button--neon:not([disabled]):hover {
+  background-color: rgba(var(--ofx-neon-rgb), 0.16) !important;
+  box-shadow:
+    0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
+    0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18);
+  transform: translateY(-1px);
+}
+
+.button.button--neon:not([disabled]):hover::before {
+  left: 100%;
+}
+
+/* Filled neon variant for Dawn buttons */
+.button.button--neon-fill {
+  position: relative;
+  border: 2px solid rgb(var(--ofx-neon-rgb)) !important;
+  background-color: rgba(var(--ofx-neon-rgb), 0.85) !important;
+  color: #050810 !important;
+  text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+  box-shadow:
+    0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
+    0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 8px rgba(255, 255, 255, 0.15);
+  transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
+  overflow: hidden;
+}
+
+.button.button--neon-fill::after {
+  box-shadow: none !important;
+}
+
+.button.button--neon-fill:not([disabled]):hover {
+  background-color: rgba(var(--ofx-neon-rgb), 1) !important;
+  color: #050810 !important;
+  box-shadow:
+    0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
+    0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
+    inset 0 0 12px rgba(255, 255, 255, 0.25);
+  transform: translateY(-1px);
+}
+
+/* Color helpers — same names as the standalone variants for parity */
+.button--neon.button--neon--cyan,
+.button--neon-fill.button--neon--cyan      { --ofx-neon-rgb: var(--ofx-cyan-rgb); }
+.button--neon.button--neon--purple,
+.button--neon-fill.button--neon--purple    { --ofx-neon-rgb: var(--ofx-purple-rgb); }
+.button--neon.button--neon--magenta,
+.button--neon-fill.button--neon--magenta   { --ofx-neon-rgb: var(--ofx-magenta-rgb); }
+.button--neon.button--neon--pink,
+.button--neon-fill.button--neon--pink      { --ofx-neon-rgb: var(--ofx-pink-rgb); }
+.button--neon.button--neon--green,
+.button--neon-fill.button--neon--green     { --ofx-neon-rgb: var(--ofx-green-rgb); }
+.button--neon.button--neon--blue,
+.button--neon-fill.button--neon--blue      { --ofx-neon-rgb: var(--ofx-blue-rgb); }
+
+/* =============================================================
+   Pulsing glow + flickering text utilities
+   ============================================================= */
+.cyber-pulse {
+  animation: ofx-cyber-pulse 2s ease-in-out infinite;
+}
+
+@keyframes ofx-cyber-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 15px rgba(var(--ofx-neon-rgb), 0.3),
+      inset 0 0 15px rgba(var(--ofx-neon-rgb), 0.1);
+  }
+  50% {
+    box-shadow:
+      0 0 25px rgba(var(--ofx-neon-rgb), 0.5),
+      inset 0 0 25px rgba(var(--ofx-neon-rgb), 0.2);
+  }
+}
+
+.cyber-border-glow {
+  border: 1px solid rgba(var(--ofx-neon-rgb), 0.4);
+  box-shadow:
+    0 0 10px rgba(var(--ofx-neon-rgb), 0.25),
+    inset 0 0 10px rgba(var(--ofx-neon-rgb), 0.08);
+  transition: all 0.25s ease;
+}
+
+.cyber-border-glow:hover {
+  border-color: rgba(var(--ofx-neon-rgb), 0.7);
+  box-shadow:
+    0 0 18px rgba(var(--ofx-neon-rgb), 0.5),
+    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.15);
+}
+
+.text-neon {
+  color: rgb(var(--ofx-neon-rgb));
+  text-shadow:
+    0 0 5px rgb(var(--ofx-neon-rgb)),
+    0 0 10px rgb(var(--ofx-neon-rgb)),
+    0 0 20px rgb(var(--ofx-neon-rgb)),
+    0 0 40px var(--ofx-cyan-dark);
+}
+
+.text-neon-flicker {
+  color: rgb(var(--ofx-neon-rgb));
+  text-shadow:
+    0 0 8px rgba(var(--ofx-neon-rgb), 0.8),
+    0 0 16px rgba(var(--ofx-neon-rgb), 0.5);
+  animation: ofx-text-flicker 3s infinite;
+}
+
+@keyframes ofx-text-flicker {
+  0%, 100% {
+    text-shadow:
+      0 0 8px rgba(var(--ofx-neon-rgb), 0.8),
+      0 0 16px rgba(var(--ofx-neon-rgb), 0.5);
+  }
+  50% {
+    text-shadow:
+      0 0 12px rgba(var(--ofx-neon-rgb), 1),
+      0 0 22px rgba(var(--ofx-neon-rgb), 0.7);
+  }
+}
+
+/* =============================================================
+   Text scrambler / decode overlay
+   See assets/neon-glitch.js for the runtime that actually mutates
+   .scramble-overlay characters during hover.
+   ============================================================= */
+[data-scramble] {
+  cursor: default;
+  position: relative;
+}
+
+[data-scramble].is-scrambling {
+  white-space: nowrap;
+}
+
+[data-scramble].is-scrambling span {
+  font-family: inherit;
+}
+
+[data-scramble] > .scramble-overlay {
+  position: absolute;
+  inset: 0;
+  display: block;
+  pointer-events: none;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-shadow: inherit;
+  white-space: inherit;
+}
+
+[data-scramble] > .scramble-overlay:empty {
+  display: none;
+}
+
+/* During the decode the original text is hidden via transparency
+   so layout stays identical before/during/after. */
+[data-scramble].is-scrambling {
+  color: transparent !important;
+  text-shadow: none !important;
+}
+
+/* =============================================================
+   Chromatic-aberration glitch animations
+   Trigger via [data-fx-glitch], [data-fx-glitch-hover],
+   [data-fx-glitch-click] for text targets, and [data-fx-glitch-box]
+   for non-text elements (cards, icon buttons).
+   ============================================================= */
+
+/* --- Hover flicker (short, subtle) --- */
+@keyframes ofx-fx-glitch-hover {
+  0% {
+    clip-path: inset(0 0 0 0);
+    text-shadow: none;
+    filter: none;
+    transform: translateX(0);
+  }
+  12% {
+    clip-path: inset(44% 0 42% 0);
+    transform: translateX(-2px);
+    text-shadow: 2px 0 rgba(0, 210, 255, 0.85), -2px 0 rgba(255, 42, 160, 0.85);
+    filter: brightness(1.1);
+  }
+  16% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(1px);
+    text-shadow: -1px 0 rgba(0, 210, 255, 0.6), 1px 0 rgba(255, 42, 160, 0.6);
+    filter: none;
+  }
+  32% {
+    clip-path: inset(12% 0 70% 0);
+    transform: translateX(-1px);
+    text-shadow: 2px 0 rgba(0, 210, 255, 0.8), -2px 0 rgba(255, 42, 160, 0.8);
+    filter: hue-rotate(8deg);
+  }
+  36% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(0);
+    text-shadow: none;
+    filter: none;
+  }
+  58% {
+    clip-path: inset(65% 0 8% 0);
+    transform: translateX(2px);
+    text-shadow: -2px 0 rgba(0, 210, 255, 0.75), 2px 0 rgba(255, 42, 160, 0.75);
+    filter: hue-rotate(-10deg) brightness(1.08);
+  }
+  62% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(0);
+    text-shadow: 1px 0 rgba(0, 210, 255, 0.3), -1px 0 rgba(255, 42, 160, 0.3);
+  }
+  82% { opacity: 0.85; }
+  100% {
+    clip-path: inset(0 0 0 0);
+    text-shadow: none;
+    filter: none;
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+/* --- Click burst (stronger, more slices, opacity stutter) --- */
+@keyframes ofx-fx-glitch-click {
+  0% {
+    clip-path: inset(0 0 0 0);
+    text-shadow: none;
+    filter: none;
+    transform: translateX(0);
+    opacity: 1;
+  }
+  8% {
+    clip-path: inset(30% 0 55% 0);
+    transform: translateX(-4px);
+    text-shadow: 4px 0 rgba(0, 210, 255, 0.95), -4px 0 rgba(255, 42, 160, 0.95);
+    filter: hue-rotate(25deg) brightness(1.25) contrast(1.15);
+  }
+  12% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(3px);
+    opacity: 0.6;
+    text-shadow: -3px 0 rgba(0, 210, 255, 0.8), 3px 0 rgba(255, 42, 160, 0.8);
+    filter: none;
+  }
+  20% {
+    clip-path: inset(72% 0 6% 0);
+    transform: translateX(-3px);
+    text-shadow: 3px 0 rgba(0, 210, 255, 0.9), -3px 0 rgba(255, 42, 160, 0.9);
+    filter: hue-rotate(-30deg) brightness(1.1);
+  }
+  28% {
+    clip-path: inset(8% 0 78% 0);
+    transform: translateX(2px);
+    text-shadow: -4px 0 rgba(0, 210, 255, 0.85), 4px 0 rgba(255, 42, 160, 0.85);
+  }
+  34% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(0);
+    opacity: 0.85;
+    filter: none;
+  }
+  52% {
+    clip-path: inset(48% 0 38% 0);
+    transform: translateX(-2px);
+    text-shadow: 3px 0 rgba(0, 210, 255, 0.8), -3px 0 rgba(255, 42, 160, 0.8);
+    filter: hue-rotate(18deg);
+  }
+  60% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(1px);
+    text-shadow: 1px 0 rgba(0, 210, 255, 0.5), -1px 0 rgba(255, 42, 160, 0.5);
+  }
+  75% { opacity: 0.92; }
+  100% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(0);
+    text-shadow: none;
+    filter: none;
+    opacity: 1;
+  }
+}
+
+/* --- Box-level chromatic aberration (cards, icon buttons) --- */
+@keyframes ofx-fx-glitch-box-hover {
+  0%, 100% {
+    clip-path: inset(0 0 0 0);
+    filter: none;
+    transform: translateX(0);
+  }
+  15% {
+    clip-path: inset(42% 0 44% 0);
+    transform: translateX(-2px);
+    filter: drop-shadow(2px 0 rgba(0, 210, 255, 0.7))
+            drop-shadow(-2px 0 rgba(255, 42, 160, 0.7))
+            brightness(1.1);
+  }
+  18% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(1px);
+    filter: drop-shadow(-1px 0 rgba(0, 210, 255, 0.45))
+            drop-shadow(1px 0 rgba(255, 42, 160, 0.45));
+  }
+  40% {
+    clip-path: inset(15% 0 65% 0);
+    transform: translateX(-1px);
+    filter: drop-shadow(2px 0 rgba(0, 210, 255, 0.65))
+            drop-shadow(-2px 0 rgba(255, 42, 160, 0.65))
+            hue-rotate(10deg);
+  }
+  44% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(0);
+    filter: none;
+  }
+  68% {
+    clip-path: inset(60% 0 8% 0);
+    transform: translateX(2px);
+    filter: drop-shadow(-2px 0 rgba(0, 210, 255, 0.6))
+            drop-shadow(2px 0 rgba(255, 42, 160, 0.6))
+            hue-rotate(-8deg);
+  }
+  82% { opacity: 0.88; }
+}
+
+@keyframes ofx-fx-glitch-box-click {
+  0%, 100% {
+    clip-path: inset(0 0 0 0);
+    filter: none;
+    transform: translateX(0);
+    opacity: 1;
+  }
+  10% {
+    clip-path: inset(32% 0 52% 0);
+    transform: translateX(-4px);
+    filter: drop-shadow(4px 0 rgba(0, 210, 255, 0.95))
+            drop-shadow(-4px 0 rgba(255, 42, 160, 0.95))
+            brightness(1.3) contrast(1.2);
+  }
+  14% {
+    clip-path: inset(0 0 0 0);
+    transform: translateX(3px);
+    opacity: 0.55;
+    filter: drop-shadow(-3px 0 rgba(0, 210, 255, 0.85))
+            drop-shadow(3px 0 rgba(255, 42, 160, 0.85));
+  }
+  24% {
+    clip-path: inset(70% 0 6% 0);
+    transform: translateX(-3px);
+    filter: drop-shadow(3px 0 rgba(0, 210, 255, 0.9))
+            drop-shadow(-3px 0 rgba(255, 42, 160, 0.9))
+            hue-rotate(-28deg);
+  }
+  32% {
+    clip-path: inset(8% 0 76% 0);
+    transform: translateX(2px);
+    filter: drop-shadow(-4px 0 rgba(0, 210, 255, 0.85))
+            drop-shadow(4px 0 rgba(255, 42, 160, 0.85))
+            hue-rotate(18deg);
+  }
+  38% {
+    clip-path: inset(0 0 0 0);
+    opacity: 0.8;
+    filter: none;
+  }
+  55% {
+    clip-path: inset(46% 0 38% 0);
+    transform: translateX(-2px);
+    filter: drop-shadow(2px 0 rgba(0, 210, 255, 0.7))
+            drop-shadow(-2px 0 rgba(255, 42, 160, 0.7));
+  }
+  78% { opacity: 0.92; }
+}
+
+[data-fx-glitch],
+[data-fx-glitch-hover],
+[data-fx-glitch-click],
+[data-fx-glitch-box] {
+  will-change: clip-path, transform, filter, opacity, text-shadow;
+}
+
+[data-fx-glitch]:hover,
+[data-fx-glitch-hover]:hover {
+  animation: ofx-fx-glitch-hover 0.45s steps(12, end);
+}
+
+[data-fx-glitch]:active,
+[data-fx-glitch-click]:active {
+  animation: ofx-fx-glitch-click 0.32s steps(14, end);
+}
+
+[data-fx-glitch-box]:hover {
+  animation: ofx-fx-glitch-box-hover 0.45s steps(12, end);
+}
+
+[data-fx-glitch-box]:active {
+  animation: ofx-fx-glitch-box-click 0.32s steps(14, end);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-fx-glitch]:hover,
+  [data-fx-glitch-hover]:hover,
+  [data-fx-glitch]:active,
+  [data-fx-glitch-click]:active,
+  [data-fx-glitch-box]:hover,
+  [data-fx-glitch-box]:active,
+  .cyber-pulse,
+  .text-neon-flicker {
+    animation: none !important;
+  }
+}

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -279,7 +279,7 @@
     0 0 5px rgb(var(--ofx-neon-rgb)),
     0 0 10px rgb(var(--ofx-neon-rgb)),
     0 0 20px rgb(var(--ofx-neon-rgb)),
-    0 0 40px var(--ofx-cyan-dark);
+    0 0 40px rgba(var(--ofx-neon-rgb), 0.4);
 }
 
 .text-neon-flicker {
@@ -313,10 +313,6 @@
   position: relative;
 }
 
-[data-scramble].is-scrambling {
-  white-space: nowrap;
-}
-
 [data-scramble].is-scrambling span {
   font-family: inherit;
 }
@@ -330,6 +326,7 @@
   color: inherit;
   letter-spacing: inherit;
   text-shadow: inherit;
+  text-transform: inherit;
   white-space: inherit;
 }
 

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -35,6 +35,12 @@
   /* Default neon accent — overridable per-button via --ofx-neon-rgb */
   --ofx-neon-rgb: var(--ofx-cyan-rgb);
   --ofx-neon: rgb(var(--ofx-neon-rgb));
+
+  /* PowerGlitch slice ghost colors. Defaults match OmniTask's
+     cyan/magenta chromatic aberration. Overridden on neon buttons so
+     the glitch slices conform to whichever button color is in play. */
+  --ofx-glitch-color-1: 0, 210, 255;
+  --ofx-glitch-color-2: 255, 42, 160;
 }
 
 /* =============================================================
@@ -140,17 +146,37 @@
 .ofx-neon--blue    { --ofx-neon-rgb: var(--ofx-blue-rgb); }
 
 /* =============================================================
-   Dawn .button neon overlay — applies neon glow to existing
-   theme buttons (.button--primary, .button--secondary). Use
-   alongside .button to get an OmniTask-flavored hover without
-   discarding Dawn's box model.
+   Dawn .button neon overlay — applies neon glow to existing theme
+   buttons (.button--primary, .button--secondary). Default behavior
+   pulls colors from the active Shopify color scheme:
+
+     Outline (.button--neon):
+       - border + label + glow = scheme's secondary-button-text color
+         (which is the outline color the merchant picked).
+
+     Fill (.button--neon-fill):
+       - border + bg + outer glow = scheme's button color.
+       - label = scheme's button-label color, with a white halo.
+
+   Pick one of the .button--neon--{cyan,purple,...} modifiers to
+   force a specific neon hue regardless of the scheme.
    ============================================================= */
+
+/* Outline neon — uses scheme's secondary-button-text as the single
+   accent color for border, label, and box glow. */
 .button.button--neon {
+  /* --ofx-neon-rgb: scheme outline color, can be overridden by the
+     color-modifier classes below. */
+  --ofx-neon-rgb: var(--color-secondary-button-text);
+  --ofx-glitch-color-1: var(--ofx-neon-rgb);
+  --ofx-glitch-color-2: var(--ofx-neon-rgb);
   position: relative;
   border: 2px solid rgb(var(--ofx-neon-rgb)) !important;
   background-color: rgba(var(--ofx-neon-rgb), 0.08) !important;
   color: rgb(var(--ofx-neon-rgb)) !important;
-  text-shadow: 0 0 10px rgba(var(--ofx-neon-rgb), 0.7);
+  text-shadow:
+    0 0 6px rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 14px rgba(var(--ofx-neon-rgb), 0.45);
   box-shadow:
     0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
     0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
@@ -195,13 +221,21 @@
   left: 100%;
 }
 
-/* Filled neon variant for Dawn buttons */
+/* Fill neon — border + bg + outer glow from scheme button color,
+   label from scheme button-label color, with a white halo so the
+   label still reads "neon" against the dark fill. */
 .button.button--neon-fill {
+  --ofx-neon-rgb: var(--color-button);
+  --ofx-button-label-rgb: var(--color-button-text);
+  --ofx-glitch-color-1: var(--ofx-neon-rgb);
+  --ofx-glitch-color-2: var(--ofx-button-label-rgb);
   position: relative;
   border: 2px solid rgb(var(--ofx-neon-rgb)) !important;
   background-color: rgba(var(--ofx-neon-rgb), 0.85) !important;
-  color: #050810 !important;
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+  color: rgb(var(--ofx-button-label-rgb)) !important;
+  text-shadow:
+    0 0 6px rgba(255, 255, 255, 0.85),
+    0 0 14px rgba(255, 255, 255, 0.45);
   box-shadow:
     0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
     0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
@@ -216,7 +250,7 @@
 
 .button.button--neon-fill:not([disabled]):hover {
   background-color: rgba(var(--ofx-neon-rgb), 1) !important;
-  color: #050810 !important;
+  color: rgb(var(--ofx-button-label-rgb)) !important;
   box-shadow:
     0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
     0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
@@ -224,19 +258,20 @@
   transform: translateY(-1px);
 }
 
-/* Color helpers — same names as the standalone variants for parity */
+/* Explicit color overrides — apply alongside .button--neon[-fill] to
+   force a particular neon hue regardless of the active scheme. */
 .button--neon.button--neon--cyan,
-.button--neon-fill.button--neon--cyan      { --ofx-neon-rgb: var(--ofx-cyan-rgb); }
+.button--neon-fill.button--neon--cyan      { --ofx-neon-rgb: var(--ofx-cyan-rgb);    --ofx-glitch-color-1: var(--ofx-cyan-rgb);    --ofx-glitch-color-2: var(--ofx-magenta-rgb); }
 .button--neon.button--neon--purple,
-.button--neon-fill.button--neon--purple    { --ofx-neon-rgb: var(--ofx-purple-rgb); }
+.button--neon-fill.button--neon--purple    { --ofx-neon-rgb: var(--ofx-purple-rgb);  --ofx-glitch-color-1: var(--ofx-purple-rgb);  --ofx-glitch-color-2: var(--ofx-cyan-rgb); }
 .button--neon.button--neon--magenta,
-.button--neon-fill.button--neon--magenta   { --ofx-neon-rgb: var(--ofx-magenta-rgb); }
+.button--neon-fill.button--neon--magenta   { --ofx-neon-rgb: var(--ofx-magenta-rgb); --ofx-glitch-color-1: var(--ofx-magenta-rgb); --ofx-glitch-color-2: var(--ofx-cyan-rgb); }
 .button--neon.button--neon--pink,
-.button--neon-fill.button--neon--pink      { --ofx-neon-rgb: var(--ofx-pink-rgb); }
+.button--neon-fill.button--neon--pink      { --ofx-neon-rgb: var(--ofx-pink-rgb);    --ofx-glitch-color-1: var(--ofx-pink-rgb);    --ofx-glitch-color-2: var(--ofx-cyan-rgb); }
 .button--neon.button--neon--green,
-.button--neon-fill.button--neon--green     { --ofx-neon-rgb: var(--ofx-green-rgb); }
+.button--neon-fill.button--neon--green     { --ofx-neon-rgb: var(--ofx-green-rgb);   --ofx-glitch-color-1: var(--ofx-green-rgb);   --ofx-glitch-color-2: var(--ofx-magenta-rgb); }
 .button--neon.button--neon--blue,
-.button--neon-fill.button--neon--blue      { --ofx-neon-rgb: var(--ofx-blue-rgb); }
+.button--neon-fill.button--neon--blue      { --ofx-neon-rgb: var(--ofx-blue-rgb);    --ofx-glitch-color-1: var(--ofx-blue-rgb);    --ofx-glitch-color-2: var(--ofx-magenta-rgb); }
 
 /* =============================================================
    Pulsing glow + flickering text utilities
@@ -359,19 +394,19 @@
   12% {
     clip-path: inset(44% 0 42% 0);
     transform: translateX(-2px);
-    text-shadow: 2px 0 rgba(0, 210, 255, 0.85), -2px 0 rgba(255, 42, 160, 0.85);
+    text-shadow: 2px 0 rgba(var(--ofx-glitch-color-1), 0.85), -2px 0 rgba(var(--ofx-glitch-color-2), 0.85);
     filter: brightness(1.1);
   }
   16% {
     clip-path: inset(0 0 0 0);
     transform: translateX(1px);
-    text-shadow: -1px 0 rgba(0, 210, 255, 0.6), 1px 0 rgba(255, 42, 160, 0.6);
+    text-shadow: -1px 0 rgba(var(--ofx-glitch-color-1), 0.6), 1px 0 rgba(var(--ofx-glitch-color-2), 0.6);
     filter: none;
   }
   32% {
     clip-path: inset(12% 0 70% 0);
     transform: translateX(-1px);
-    text-shadow: 2px 0 rgba(0, 210, 255, 0.8), -2px 0 rgba(255, 42, 160, 0.8);
+    text-shadow: 2px 0 rgba(var(--ofx-glitch-color-1), 0.8), -2px 0 rgba(var(--ofx-glitch-color-2), 0.8);
     filter: hue-rotate(8deg);
   }
   36% {
@@ -383,13 +418,13 @@
   58% {
     clip-path: inset(65% 0 8% 0);
     transform: translateX(2px);
-    text-shadow: -2px 0 rgba(0, 210, 255, 0.75), 2px 0 rgba(255, 42, 160, 0.75);
+    text-shadow: -2px 0 rgba(var(--ofx-glitch-color-1), 0.75), 2px 0 rgba(var(--ofx-glitch-color-2), 0.75);
     filter: hue-rotate(-10deg) brightness(1.08);
   }
   62% {
     clip-path: inset(0 0 0 0);
     transform: translateX(0);
-    text-shadow: 1px 0 rgba(0, 210, 255, 0.3), -1px 0 rgba(255, 42, 160, 0.3);
+    text-shadow: 1px 0 rgba(var(--ofx-glitch-color-1), 0.3), -1px 0 rgba(var(--ofx-glitch-color-2), 0.3);
   }
   82% { opacity: 0.85; }
   100% {
@@ -413,26 +448,26 @@
   8% {
     clip-path: inset(30% 0 55% 0);
     transform: translateX(-4px);
-    text-shadow: 4px 0 rgba(0, 210, 255, 0.95), -4px 0 rgba(255, 42, 160, 0.95);
+    text-shadow: 4px 0 rgba(var(--ofx-glitch-color-1), 0.95), -4px 0 rgba(var(--ofx-glitch-color-2), 0.95);
     filter: hue-rotate(25deg) brightness(1.25) contrast(1.15);
   }
   12% {
     clip-path: inset(0 0 0 0);
     transform: translateX(3px);
     opacity: 0.6;
-    text-shadow: -3px 0 rgba(0, 210, 255, 0.8), 3px 0 rgba(255, 42, 160, 0.8);
+    text-shadow: -3px 0 rgba(var(--ofx-glitch-color-1), 0.8), 3px 0 rgba(var(--ofx-glitch-color-2), 0.8);
     filter: none;
   }
   20% {
     clip-path: inset(72% 0 6% 0);
     transform: translateX(-3px);
-    text-shadow: 3px 0 rgba(0, 210, 255, 0.9), -3px 0 rgba(255, 42, 160, 0.9);
+    text-shadow: 3px 0 rgba(var(--ofx-glitch-color-1), 0.9), -3px 0 rgba(var(--ofx-glitch-color-2), 0.9);
     filter: hue-rotate(-30deg) brightness(1.1);
   }
   28% {
     clip-path: inset(8% 0 78% 0);
     transform: translateX(2px);
-    text-shadow: -4px 0 rgba(0, 210, 255, 0.85), 4px 0 rgba(255, 42, 160, 0.85);
+    text-shadow: -4px 0 rgba(var(--ofx-glitch-color-1), 0.85), 4px 0 rgba(var(--ofx-glitch-color-2), 0.85);
   }
   34% {
     clip-path: inset(0 0 0 0);
@@ -443,13 +478,13 @@
   52% {
     clip-path: inset(48% 0 38% 0);
     transform: translateX(-2px);
-    text-shadow: 3px 0 rgba(0, 210, 255, 0.8), -3px 0 rgba(255, 42, 160, 0.8);
+    text-shadow: 3px 0 rgba(var(--ofx-glitch-color-1), 0.8), -3px 0 rgba(var(--ofx-glitch-color-2), 0.8);
     filter: hue-rotate(18deg);
   }
   60% {
     clip-path: inset(0 0 0 0);
     transform: translateX(1px);
-    text-shadow: 1px 0 rgba(0, 210, 255, 0.5), -1px 0 rgba(255, 42, 160, 0.5);
+    text-shadow: 1px 0 rgba(var(--ofx-glitch-color-1), 0.5), -1px 0 rgba(var(--ofx-glitch-color-2), 0.5);
   }
   75% { opacity: 0.92; }
   100% {
@@ -471,21 +506,21 @@
   15% {
     clip-path: inset(42% 0 44% 0);
     transform: translateX(-2px);
-    filter: drop-shadow(2px 0 rgba(0, 210, 255, 0.7))
-            drop-shadow(-2px 0 rgba(255, 42, 160, 0.7))
+    filter: drop-shadow(2px 0 rgba(var(--ofx-glitch-color-1), 0.7))
+            drop-shadow(-2px 0 rgba(var(--ofx-glitch-color-2), 0.7))
             brightness(1.1);
   }
   18% {
     clip-path: inset(0 0 0 0);
     transform: translateX(1px);
-    filter: drop-shadow(-1px 0 rgba(0, 210, 255, 0.45))
-            drop-shadow(1px 0 rgba(255, 42, 160, 0.45));
+    filter: drop-shadow(-1px 0 rgba(var(--ofx-glitch-color-1), 0.45))
+            drop-shadow(1px 0 rgba(var(--ofx-glitch-color-2), 0.45));
   }
   40% {
     clip-path: inset(15% 0 65% 0);
     transform: translateX(-1px);
-    filter: drop-shadow(2px 0 rgba(0, 210, 255, 0.65))
-            drop-shadow(-2px 0 rgba(255, 42, 160, 0.65))
+    filter: drop-shadow(2px 0 rgba(var(--ofx-glitch-color-1), 0.65))
+            drop-shadow(-2px 0 rgba(var(--ofx-glitch-color-2), 0.65))
             hue-rotate(10deg);
   }
   44% {
@@ -496,8 +531,8 @@
   68% {
     clip-path: inset(60% 0 8% 0);
     transform: translateX(2px);
-    filter: drop-shadow(-2px 0 rgba(0, 210, 255, 0.6))
-            drop-shadow(2px 0 rgba(255, 42, 160, 0.6))
+    filter: drop-shadow(-2px 0 rgba(var(--ofx-glitch-color-1), 0.6))
+            drop-shadow(2px 0 rgba(var(--ofx-glitch-color-2), 0.6))
             hue-rotate(-8deg);
   }
   82% { opacity: 0.88; }
@@ -513,29 +548,29 @@
   10% {
     clip-path: inset(32% 0 52% 0);
     transform: translateX(-4px);
-    filter: drop-shadow(4px 0 rgba(0, 210, 255, 0.95))
-            drop-shadow(-4px 0 rgba(255, 42, 160, 0.95))
+    filter: drop-shadow(4px 0 rgba(var(--ofx-glitch-color-1), 0.95))
+            drop-shadow(-4px 0 rgba(var(--ofx-glitch-color-2), 0.95))
             brightness(1.3) contrast(1.2);
   }
   14% {
     clip-path: inset(0 0 0 0);
     transform: translateX(3px);
     opacity: 0.55;
-    filter: drop-shadow(-3px 0 rgba(0, 210, 255, 0.85))
-            drop-shadow(3px 0 rgba(255, 42, 160, 0.85));
+    filter: drop-shadow(-3px 0 rgba(var(--ofx-glitch-color-1), 0.85))
+            drop-shadow(3px 0 rgba(var(--ofx-glitch-color-2), 0.85));
   }
   24% {
     clip-path: inset(70% 0 6% 0);
     transform: translateX(-3px);
-    filter: drop-shadow(3px 0 rgba(0, 210, 255, 0.9))
-            drop-shadow(-3px 0 rgba(255, 42, 160, 0.9))
+    filter: drop-shadow(3px 0 rgba(var(--ofx-glitch-color-1), 0.9))
+            drop-shadow(-3px 0 rgba(var(--ofx-glitch-color-2), 0.9))
             hue-rotate(-28deg);
   }
   32% {
     clip-path: inset(8% 0 76% 0);
     transform: translateX(2px);
-    filter: drop-shadow(-4px 0 rgba(0, 210, 255, 0.85))
-            drop-shadow(4px 0 rgba(255, 42, 160, 0.85))
+    filter: drop-shadow(-4px 0 rgba(var(--ofx-glitch-color-1), 0.85))
+            drop-shadow(4px 0 rgba(var(--ofx-glitch-color-2), 0.85))
             hue-rotate(18deg);
   }
   38% {
@@ -546,8 +581,8 @@
   55% {
     clip-path: inset(46% 0 38% 0);
     transform: translateX(-2px);
-    filter: drop-shadow(2px 0 rgba(0, 210, 255, 0.7))
-            drop-shadow(-2px 0 rgba(255, 42, 160, 0.7));
+    filter: drop-shadow(2px 0 rgba(var(--ofx-glitch-color-1), 0.7))
+            drop-shadow(-2px 0 rgba(var(--ofx-glitch-color-2), 0.7));
   }
   78% { opacity: 0.92; }
 }
@@ -574,6 +609,22 @@
 }
 
 [data-fx-glitch-box]:active {
+  animation: ofx-fx-glitch-box-click 0.32s steps(14, end);
+}
+
+/* For buttons specifically, the box-level keyframes (drop-shadow on
+   the whole element) read more like PowerGlitch's slice effect than
+   the text-only chromatic-aberration. Override [data-fx-glitch] on
+   buttons so a single attribute gives the right look automatically. */
+.button[data-fx-glitch]:hover,
+.ofx-neon-button[data-fx-glitch]:hover,
+.ofx-neon-button-fill[data-fx-glitch]:hover {
+  animation: ofx-fx-glitch-box-hover 0.45s steps(12, end);
+}
+
+.button[data-fx-glitch]:active,
+.ofx-neon-button[data-fx-glitch]:active,
+.ofx-neon-button-fill[data-fx-glitch]:active {
   animation: ofx-fx-glitch-box-click 0.32s steps(14, end);
 }
 

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -161,10 +161,13 @@
   text-shadow:
     0 0 6px rgba(var(--ofx-neon-rgb), 0.85),
     0 0 14px rgba(var(--ofx-neon-rgb), 0.45);
+  /* Same symmetric inward + outward halo as .button.button--neon. */
   box-shadow:
-    0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
-    0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
-    inset 0 0 12px rgba(var(--ofx-neon-rgb), 0.08);
+    0 0 8px rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 18px rgba(var(--ofx-neon-rgb), 0.28),
+    0 0 36px rgba(var(--ofx-neon-rgb), 0.14),
+    inset 0 0 8px rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.14);
   transition: all 0.25s ease;
   overflow: hidden;
 }
@@ -194,9 +197,11 @@
     rgba(var(--ofx-neon-rgb), 0.22)
   );
   box-shadow:
-    0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
-    0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
-    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18);
+    0 0 14px rgba(var(--ofx-neon-rgb), 0.7),
+    0 0 28px rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 56px rgba(var(--ofx-neon-rgb), 0.22),
+    inset 0 0 14px rgba(var(--ofx-neon-rgb), 0.45),
+    inset 0 0 26px rgba(var(--ofx-neon-rgb), 0.22);
   transform: translateY(-1px);
 }
 
@@ -216,9 +221,11 @@
     0 0 6px rgba(255, 255, 255, 0.85),
     0 0 14px rgba(255, 255, 255, 0.45);
   box-shadow:
-    0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
-    0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
-    inset 0 0 8px rgba(255, 255, 255, 0.15);
+    0 0 10px rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 24px rgba(var(--ofx-neon-rgb), 0.35),
+    0 0 48px rgba(var(--ofx-neon-rgb), 0.18),
+    inset 0 0 6px rgba(255, 255, 255, 0.22),
+    inset 0 0 18px rgba(255, 255, 255, 0.08);
 }
 
 .ofx-neon-button-fill:hover {
@@ -227,9 +234,11 @@
   color: #050810;
   transform: translateY(-1px);
   box-shadow:
-    0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
-    0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
-    inset 0 0 12px rgba(255, 255, 255, 0.25);
+    0 0 16px rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 36px rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 70px rgba(var(--ofx-neon-rgb), 0.28),
+    inset 0 0 10px rgba(255, 255, 255, 0.35),
+    inset 0 0 22px rgba(255, 255, 255, 0.15);
 }
 
 /* Color variants — apply alongside .ofx-neon-button[-fill] */
@@ -286,10 +295,17 @@
   text-shadow:
     0 0 6px rgba(var(--ofx-neon-rgb), 0.85),
     0 0 14px rgba(var(--ofx-neon-rgb), 0.45);
+  /* Symmetric glow — three outer halos at increasing radius for a
+     soft falloff outward, plus two inset halos so the glow also
+     pulses inward. The 0/0 offset on every shadow keeps the halo
+     centered, so it spreads evenly on all four sides instead of
+     drifting toward Dawn's directional --buttons-shadow-* offsets. */
   box-shadow:
-    0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
-    0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
-    inset 0 0 12px rgba(var(--ofx-neon-rgb), 0.08);
+    0 0 8px rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 18px rgba(var(--ofx-neon-rgb), 0.28),
+    0 0 36px rgba(var(--ofx-neon-rgb), 0.14),
+    inset 0 0 8px rgba(var(--ofx-neon-rgb), 0.3),
+    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.14);
   transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
   overflow: hidden;
 }
@@ -300,6 +316,11 @@
 }
 
 .button.button--neon::before {
+  /* Override Dawn's directional drop-shadow box-shadow that was
+     causing the asymmetric "hard edge on one side, blur on the
+     others" look on outline buttons. The symmetric box-shadow
+     stack on .button.button--neon above provides the glow. */
+  box-shadow: none !important;
   content: '';
   position: absolute;
   top: 0;
@@ -323,10 +344,15 @@
     rgba(var(--ofx-neon-rgb), 0.22),
     rgba(var(--ofx-neon-rgb), 0.22)
   ) !important;
+  /* Same symmetric inward + outward glow as the resting state, just
+     punched up — outer halos brighter + reaching further, inner
+     halos thicker. */
   box-shadow:
-    0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
-    0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
-    inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18);
+    0 0 14px rgba(var(--ofx-neon-rgb), 0.7),
+    0 0 28px rgba(var(--ofx-neon-rgb), 0.45),
+    0 0 56px rgba(var(--ofx-neon-rgb), 0.22),
+    inset 0 0 14px rgba(var(--ofx-neon-rgb), 0.45),
+    inset 0 0 26px rgba(var(--ofx-neon-rgb), 0.22);
   transform: translateY(-1px);
 }
 
@@ -349,10 +375,16 @@
   text-shadow:
     0 0 6px rgba(255, 255, 255, 0.85),
     0 0 14px rgba(255, 255, 255, 0.45);
+  /* Symmetric outward halo at three radii + a white inset rim so the
+     glow reads as both inward and outward, not biased to one side
+     by Dawn's --buttons-shadow-* offsets (which are suppressed on
+     the ::before pseudo-element). */
   box-shadow:
-    0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
-    0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
-    inset 0 0 8px rgba(255, 255, 255, 0.15);
+    0 0 10px rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 24px rgba(var(--ofx-neon-rgb), 0.35),
+    0 0 48px rgba(var(--ofx-neon-rgb), 0.18),
+    inset 0 0 6px rgba(255, 255, 255, 0.22),
+    inset 0 0 18px rgba(255, 255, 255, 0.08);
   transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
   overflow: hidden;
 }
@@ -361,13 +393,22 @@
   box-shadow: none !important;
 }
 
+.button.button--neon-fill::before {
+  /* Same fix as .button--neon — kill Dawn's directional drop shadow
+     so the symmetric box-shadow stack on the button itself reads as
+     an even halo on all four sides. */
+  box-shadow: none !important;
+}
+
 .button.button--neon-fill:not([disabled]):hover {
   background-color: rgba(var(--ofx-neon-rgb), 1) !important;
   color: rgb(var(--ofx-button-label-rgb)) !important;
   box-shadow:
-    0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
-    0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
-    inset 0 0 12px rgba(255, 255, 255, 0.25);
+    0 0 16px rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 36px rgba(var(--ofx-neon-rgb), 0.55),
+    0 0 70px rgba(var(--ofx-neon-rgb), 0.28),
+    inset 0 0 10px rgba(255, 255, 255, 0.35),
+    inset 0 0 22px rgba(255, 255, 255, 0.15);
   transform: translateY(-1px);
 }
 

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -60,6 +60,7 @@
    ============================================================= */
 .ofx-neon-button,
 .ofx-neon-button-fill {
+  --ofx-neon-fill-rgb: 5, 8, 16;
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -72,10 +73,16 @@
   letter-spacing: 0.08em;
   text-decoration: none;
   cursor: pointer;
-  background: rgba(var(--ofx-neon-rgb), 0.08);
+  background-color: rgba(var(--ofx-neon-fill-rgb), 0.78);
+  background-image: linear-gradient(
+    rgba(var(--ofx-neon-rgb), 0.12),
+    rgba(var(--ofx-neon-rgb), 0.12)
+  );
   border: 2px solid rgb(var(--ofx-neon-rgb));
   color: rgb(var(--ofx-neon-rgb));
-  text-shadow: 0 0 10px rgba(var(--ofx-neon-rgb), 0.7);
+  text-shadow:
+    0 0 6px rgba(var(--ofx-neon-rgb), 0.85),
+    0 0 14px rgba(var(--ofx-neon-rgb), 0.45);
   box-shadow:
     0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
     0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
@@ -102,9 +109,12 @@
   pointer-events: none;
 }
 
-.ofx-neon-button:hover,
-.ofx-neon-button-fill:hover {
-  background: rgba(var(--ofx-neon-rgb), 0.16);
+.ofx-neon-button:hover {
+  background-color: rgba(var(--ofx-neon-fill-rgb), 0.85);
+  background-image: linear-gradient(
+    rgba(var(--ofx-neon-rgb), 0.22),
+    rgba(var(--ofx-neon-rgb), 0.22)
+  );
   box-shadow:
     0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
     0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
@@ -117,11 +127,16 @@
   left: 100%;
 }
 
-/* Filled variant — neon background, dark text */
+/* Filled variant — neon background with white-haloed dark label.
+   Override the dark base + tint set on the shared rule above so the
+   fill reads as a solid neon panel. */
 .ofx-neon-button-fill {
-  background: rgba(var(--ofx-neon-rgb), 0.85);
+  background-color: rgba(var(--ofx-neon-rgb), 0.9);
+  background-image: none;
   color: #050810;
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+  text-shadow:
+    0 0 6px rgba(255, 255, 255, 0.85),
+    0 0 14px rgba(255, 255, 255, 0.45);
   box-shadow:
     0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
     0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
@@ -129,8 +144,10 @@
 }
 
 .ofx-neon-button-fill:hover {
-  background: rgba(var(--ofx-neon-rgb), 1);
+  background-color: rgba(var(--ofx-neon-rgb), 1);
+  background-image: none;
   color: #050810;
+  transform: translateY(-1px);
   box-shadow:
     0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
     0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
@@ -163,16 +180,30 @@
    ============================================================= */
 
 /* Outline neon — uses scheme's secondary-button-text as the single
-   accent color for border, label, and box glow. */
+   accent color for border, label, and box glow. The fill uses a
+   dark navy base (overridable via --ofx-neon-fill-rgb) layered with
+   a subtle neon tint, so the button reads as a solid darker shape
+   regardless of the section background — not a near-transparent
+   pane that fades into the page. */
 .button.button--neon {
   /* --ofx-neon-rgb: scheme outline color, can be overridden by the
-     color-modifier classes below. */
+     color-modifier classes below.
+     --ofx-neon-fill-rgb: dark fill base. Defaults to OmniTask's
+     deep cyber-blue; merchants can override per-button via inline
+     style if a particular section needs a different backdrop. */
   --ofx-neon-rgb: var(--color-secondary-button-text);
+  --ofx-neon-fill-rgb: 5, 8, 16;
   --ofx-glitch-color-1: var(--ofx-neon-rgb);
   --ofx-glitch-color-2: var(--ofx-neon-rgb);
   position: relative;
   border: 2px solid rgb(var(--ofx-neon-rgb)) !important;
-  background-color: rgba(var(--ofx-neon-rgb), 0.08) !important;
+  /* Layered backgrounds — Liquid CSS engine paints first declared on
+     top, so the neon tint sits over the dark base. */
+  background-color: rgba(var(--ofx-neon-fill-rgb), 0.78) !important;
+  background-image: linear-gradient(
+    rgba(var(--ofx-neon-rgb), 0.12),
+    rgba(var(--ofx-neon-rgb), 0.12)
+  ) !important;
   color: rgb(var(--ofx-neon-rgb)) !important;
   text-shadow:
     0 0 6px rgba(var(--ofx-neon-rgb), 0.85),
@@ -209,7 +240,11 @@
 }
 
 .button.button--neon:not([disabled]):hover {
-  background-color: rgba(var(--ofx-neon-rgb), 0.16) !important;
+  background-color: rgba(var(--ofx-neon-fill-rgb), 0.85) !important;
+  background-image: linear-gradient(
+    rgba(var(--ofx-neon-rgb), 0.22),
+    rgba(var(--ofx-neon-rgb), 0.22)
+  ) !important;
   box-shadow:
     0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
     0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
@@ -612,20 +647,19 @@
   animation: ofx-fx-glitch-box-click 0.32s steps(14, end);
 }
 
-/* For buttons specifically, the box-level keyframes (drop-shadow on
-   the whole element) read more like PowerGlitch's slice effect than
-   the text-only chromatic-aberration. Override [data-fx-glitch] on
-   buttons so a single attribute gives the right look automatically. */
-.button[data-fx-glitch]:hover,
-.ofx-neon-button[data-fx-glitch]:hover,
-.ofx-neon-button-fill[data-fx-glitch]:hover {
-  animation: ofx-fx-glitch-box-hover 0.45s steps(12, end);
-}
-
-.button[data-fx-glitch]:active,
-.ofx-neon-button[data-fx-glitch]:active,
-.ofx-neon-button-fill[data-fx-glitch]:active {
-  animation: ofx-fx-glitch-box-click 0.32s steps(14, end);
+/* Buttons get the JS PowerGlitch slice port (see neon-glitch.js).
+   Suppress the CSS text-shadow keyframes on buttons so the two don't
+   double-fire. The bound JS sentinel data-pg-bound is set as soon as
+   neon-glitch.js scans the element, so this rule kicks in once the
+   runtime is in place. Non-button elements still use the keyframe
+   chromatic-aberration above. */
+.button[data-fx-glitch][data-pg-bound]:hover,
+.ofx-neon-button[data-fx-glitch][data-pg-bound]:hover,
+.ofx-neon-button-fill[data-fx-glitch][data-pg-bound]:hover,
+.button[data-fx-glitch][data-pg-bound]:active,
+.ofx-neon-button[data-fx-glitch][data-pg-bound]:active,
+.ofx-neon-button-fill[data-fx-glitch][data-pg-bound]:active {
+  animation: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -627,32 +627,156 @@
 [data-fx-glitch-click],
 [data-fx-glitch-box] {
   will-change: clip-path, transform, filter, opacity, text-shadow;
+  /* Per-element override of animation length. JS may also set this
+     inline based on the resolved glitch config; the fallback keeps
+     the animation working when JS hasn't run yet. */
+  --ofx-glitch-duration: 450ms;
 }
 
-[data-fx-glitch]:hover,
-[data-fx-glitch-hover]:hover {
-  animation: ofx-fx-glitch-hover 0.45s steps(12, end);
+/* =============================================================
+   Shake — quick whole-element jitter. No clip-path, no filters.
+   Useful for elements whose internal text would distort badly under
+   the chromatic variants (icon buttons, image cards, etc.).
+   ============================================================= */
+@keyframes ofx-fx-shake {
+  0%   { transform: translate(0, 0); }
+  10%  { transform: translate(-2px, -1px); }
+  20%  { transform: translate(2px, 1px); }
+  30%  { transform: translate(-3px, 2px); }
+  45%  { transform: translate(3px, -2px); }
+  60%  { transform: translate(-2px, 1px); }
+  75%  { transform: translate(1px, -1px); }
+  100% { transform: translate(0, 0); }
 }
 
-[data-fx-glitch]:active,
-[data-fx-glitch-click]:active {
-  animation: ofx-fx-glitch-click 0.32s steps(14, end);
+/* =============================================================
+   Flicker — opacity stutter with a brief brightness lift mid-anim.
+   Reads as a CRT power surge.
+   ============================================================= */
+@keyframes ofx-fx-flicker {
+  0%, 100% { opacity: 1; filter: brightness(1); }
+  10%      { opacity: 0.55; filter: brightness(1.3); }
+  20%      { opacity: 1;    filter: brightness(0.95); }
+  35%      { opacity: 0.7;  filter: brightness(1.2); }
+  50%      { opacity: 1;    filter: brightness(1.05); }
+  68%      { opacity: 0.45; filter: brightness(1.4); }
+  78%      { opacity: 0.95; filter: brightness(1); }
+  88%      { opacity: 0.8;  filter: brightness(1.1); }
 }
 
-[data-fx-glitch-box]:hover {
-  animation: ofx-fx-glitch-box-hover 0.45s steps(12, end);
+/* =============================================================
+   RGB split — heavier chromatic-aberration variant where each
+   color channel is offset further than the standard chromatic
+   keyframes. Targets the same --ofx-glitch-color-1 / -2 vars.
+   ============================================================= */
+@keyframes ofx-fx-rgb-split {
+  0%, 100% {
+    text-shadow: none;
+    filter: none;
+    transform: translate(0, 0);
+  }
+  20% {
+    text-shadow:
+      6px 0 rgba(var(--ofx-glitch-color-1), 0.95),
+      -6px 0 rgba(var(--ofx-glitch-color-2), 0.95);
+    filter: drop-shadow(6px 0 rgba(var(--ofx-glitch-color-1), 0.6))
+            drop-shadow(-6px 0 rgba(var(--ofx-glitch-color-2), 0.6));
+    transform: translate(-1px, 0);
+  }
+  40% {
+    text-shadow:
+      -5px 0 rgba(var(--ofx-glitch-color-1), 0.85),
+      5px 0 rgba(var(--ofx-glitch-color-2), 0.85);
+    filter: drop-shadow(-5px 0 rgba(var(--ofx-glitch-color-1), 0.5))
+            drop-shadow(5px 0 rgba(var(--ofx-glitch-color-2), 0.5));
+    transform: translate(2px, 0);
+  }
+  60% {
+    text-shadow:
+      4px 0 rgba(var(--ofx-glitch-color-1), 0.9),
+      -4px 0 rgba(var(--ofx-glitch-color-2), 0.9);
+    transform: translate(-1px, 0);
+  }
+  80% {
+    text-shadow:
+      2px 0 rgba(var(--ofx-glitch-color-1), 0.5),
+      -2px 0 rgba(var(--ofx-glitch-color-2), 0.5);
+    transform: translate(0, 0);
+  }
 }
 
-[data-fx-glitch-box]:active {
-  animation: ofx-fx-glitch-box-click 0.32s steps(14, end);
+/* =============================================================
+   Type dispatch — each [data-fx-glitch-type] value maps to one
+   keyframe. JS sets data-fx-glitch-type on every element it
+   binds (from per-element data attribute or global config), so
+   these selectors fire exactly one animation per type. The
+   element's --ofx-glitch-duration controls the animation length.
+
+   Type "slice" is intentionally a no-op here — the JS
+   PowerGlitch port handles it via DOM clones.
+   ============================================================= */
+[data-fx-glitch-type="chromatic-text"]:hover,
+[data-fx-glitch-type="chromatic-text"]:focus-visible {
+  animation: ofx-fx-glitch-hover var(--ofx-glitch-duration) steps(12, end);
 }
 
-/* Buttons get the JS PowerGlitch slice port (see neon-glitch.js).
-   Suppress the CSS text-shadow keyframes on buttons so the two don't
-   double-fire. The bound JS sentinel data-pg-bound is set as soon as
-   neon-glitch.js scans the element, so this rule kicks in once the
-   runtime is in place. Non-button elements still use the keyframe
-   chromatic-aberration above. */
+[data-fx-glitch-type="chromatic-text"]:active {
+  animation: ofx-fx-glitch-click var(--ofx-glitch-duration) steps(14, end);
+}
+
+[data-fx-glitch-type="chromatic-box"]:hover,
+[data-fx-glitch-type="chromatic-box"]:focus-visible {
+  animation: ofx-fx-glitch-box-hover var(--ofx-glitch-duration) steps(12, end);
+}
+
+[data-fx-glitch-type="chromatic-box"]:active {
+  animation: ofx-fx-glitch-box-click var(--ofx-glitch-duration) steps(14, end);
+}
+
+[data-fx-glitch-type="shake"]:hover,
+[data-fx-glitch-type="shake"]:focus-visible {
+  animation: ofx-fx-shake var(--ofx-glitch-duration) ease-out;
+}
+
+[data-fx-glitch-type="flicker"]:hover,
+[data-fx-glitch-type="flicker"]:focus-visible {
+  animation: ofx-fx-flicker var(--ofx-glitch-duration) steps(10, end);
+}
+
+[data-fx-glitch-type="rgb-split"]:hover,
+[data-fx-glitch-type="rgb-split"]:focus-visible {
+  animation: ofx-fx-rgb-split var(--ofx-glitch-duration) steps(10, end);
+}
+
+[data-fx-glitch-type="slice"]:hover {
+  /* Intentionally empty — the JS PowerGlitch port animates this
+     type via DOM clones. */
+}
+
+/* Fallback for elements that haven't been touched by JS yet
+   (or with JS disabled). Keep the legacy selectors firing so the
+   chromatic-text effect runs by default — same behavior as before
+   the type system was introduced. */
+[data-fx-glitch]:not([data-fx-glitch-type]):hover,
+[data-fx-glitch-hover]:not([data-fx-glitch-type]):hover {
+  animation: ofx-fx-glitch-hover var(--ofx-glitch-duration) steps(12, end);
+}
+
+[data-fx-glitch]:not([data-fx-glitch-type]):active,
+[data-fx-glitch-click]:not([data-fx-glitch-type]):active {
+  animation: ofx-fx-glitch-click var(--ofx-glitch-duration) steps(14, end);
+}
+
+[data-fx-glitch-box]:not([data-fx-glitch-type]):hover {
+  animation: ofx-fx-glitch-box-hover var(--ofx-glitch-duration) steps(12, end);
+}
+
+[data-fx-glitch-box]:not([data-fx-glitch-type]):active {
+  animation: ofx-fx-glitch-box-click var(--ofx-glitch-duration) steps(14, end);
+}
+
+/* Buttons whose JS PowerGlitch is bound (data-pg-bound) — never
+   double-fire a CSS animation alongside it. */
 .button[data-fx-glitch][data-pg-bound]:hover,
 .ofx-neon-button[data-fx-glitch][data-pg-bound]:hover,
 .ofx-neon-button-fill[data-fx-glitch][data-pg-bound]:hover,
@@ -669,6 +793,9 @@
   [data-fx-glitch-click]:active,
   [data-fx-glitch-box]:hover,
   [data-fx-glitch-box]:active,
+  [data-fx-glitch-type]:hover,
+  [data-fx-glitch-type]:active,
+  [data-fx-glitch-type]:focus-visible,
   .cyber-pulse,
   .text-neon-flicker {
     animation: none !important;

--- a/assets/neon-glitch.css
+++ b/assets/neon-glitch.css
@@ -53,6 +53,84 @@
 }
 
 /* =============================================================
+   Scheme integration — when a section uses any Shopify color
+   scheme, glitch + decode pick up scheme-derived colors so a
+   single scheme choice configures the whole component without
+   per-button styling. Per-scheme overrides below provide a
+   tailored OmniTask palette for the scheme-omnitask-* schemes.
+
+   Cascade order:
+     1. Per-element data-fx-glitch-color attribute (highest)
+     2. Per-element CSS modifier class (.button--neon--cyan etc.)
+     3. Per-scheme override (.color-scheme-omnitask-cyan)
+     4. Generic scheme fallback (any .color-* element)
+     5. :root defaults (cyan + magenta)
+   ============================================================= */
+
+/* Generic fallback — every Shopify color scheme element auto-feeds
+   glitch colors from its own button colors. So a merchant who picks
+   any scheme (theirs or one of ours) gets glitch slices that
+   conform to that scheme's primary button + outline colors. */
+[class*=" color-"],
+[class^="color-"] {
+  --ofx-glitch-color-1: var(--color-button);
+  --ofx-glitch-color-2: var(--color-secondary-button-text);
+  --ofx-decode-color-1: rgb(var(--color-button));
+  --ofx-decode-color-2: rgb(var(--color-secondary-button-text));
+  --ofx-decode-color-3: rgb(var(--color-button));
+  --ofx-decode-color-4: rgb(var(--color-secondary-button-text));
+}
+
+/* OmniTask scheme overrides — replace the auto-derived pair with
+   curated cyan/magenta/etc. complements that match each scheme's
+   accent. Using class-on-class (.color-scheme-* alone) so any
+   section wrapper / nested element picks them up via inheritance. */
+.color-scheme-omnitask-cyan {
+  --ofx-glitch-color-1: var(--ofx-cyan-rgb);
+  --ofx-glitch-color-2: var(--ofx-magenta-rgb);
+  --ofx-decode-color-1: var(--ofx-cyan);
+  --ofx-decode-color-2: var(--ofx-pink);
+  --ofx-decode-color-3: var(--ofx-purple);
+  --ofx-decode-color-4: var(--ofx-magenta);
+}
+
+.color-scheme-omnitask-purple {
+  --ofx-glitch-color-1: var(--ofx-purple-rgb);
+  --ofx-glitch-color-2: var(--ofx-cyan-rgb);
+  --ofx-decode-color-1: var(--ofx-purple);
+  --ofx-decode-color-2: var(--ofx-cyan);
+  --ofx-decode-color-3: var(--ofx-magenta);
+  --ofx-decode-color-4: var(--ofx-pink);
+}
+
+.color-scheme-omnitask-magenta {
+  --ofx-glitch-color-1: var(--ofx-magenta-rgb);
+  --ofx-glitch-color-2: var(--ofx-cyan-rgb);
+  --ofx-decode-color-1: var(--ofx-magenta);
+  --ofx-decode-color-2: var(--ofx-cyan);
+  --ofx-decode-color-3: var(--ofx-pink);
+  --ofx-decode-color-4: var(--ofx-purple);
+}
+
+.color-scheme-omnitask-pink {
+  --ofx-glitch-color-1: var(--ofx-pink-rgb);
+  --ofx-glitch-color-2: var(--ofx-cyan-rgb);
+  --ofx-decode-color-1: var(--ofx-pink);
+  --ofx-decode-color-2: var(--ofx-cyan);
+  --ofx-decode-color-3: var(--ofx-magenta);
+  --ofx-decode-color-4: var(--ofx-purple);
+}
+
+.color-scheme-omnitask-green {
+  --ofx-glitch-color-1: var(--ofx-green-rgb);
+  --ofx-glitch-color-2: var(--ofx-magenta-rgb);
+  --ofx-decode-color-1: var(--ofx-green);
+  --ofx-decode-color-2: var(--ofx-cyan);
+  --ofx-decode-color-3: var(--ofx-yellow);
+  --ofx-decode-color-4: var(--ofx-magenta);
+}
+
+/* =============================================================
    Standalone OmniTask neon buttons (drop-in classes)
    These do not depend on Dawn's .button base styles — useful for
    custom liquid blocks or rich text where merchants want a pure

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -388,7 +388,21 @@
       return fallback;
     }
 
+    // Resolve the glitch type. Per-element data-fx-glitch-type wins,
+    // then global config, then a sensible default based on the
+    // element kind: buttons get the slice (PowerGlitch), everything
+    // else gets the chromatic-text variant.
+    var type = ds.fxGlitchType || globalCfg.type;
+    if (!type) {
+      var isButton =
+        el.classList.contains('button') ||
+        el.classList.contains('ofx-neon-button') ||
+        el.classList.contains('ofx-neon-button-fill');
+      type = isButton ? 'slice' : 'chromatic-text';
+    }
+
     return {
+      type:       type,
       sliceCount: pickInt('fxGlitchSlices', 'sliceCount', 3),
       duration:   pickInt('fxGlitchDuration', 'duration', 400),
       velocity:   pickInt('fxGlitchVelocity', 'velocity', 18),
@@ -401,7 +415,33 @@
     };
   }
 
-  function bindPowerGlitch(el) {
+  /**
+   * Front door for the glitch system — resolves the type and either
+   * binds the JS PowerGlitch slice runtime (for type === 'slice') or
+   * just stamps the type + duration on the element so the CSS rules
+   * take over. Idempotent via data-gl-bound.
+   */
+  function bindGlitch(el) {
+    if (el.dataset.glBound === 'true') return;
+    el.dataset.glBound = 'true';
+
+    var cfg = getGlitchConfig(el);
+
+    // Reflect the resolved type onto the element so the CSS
+    // [data-fx-glitch-type="..."] selectors fire the right keyframe.
+    if (!el.dataset.fxGlitchType) {
+      el.dataset.fxGlitchType = cfg.type;
+    }
+    el.style.setProperty('--ofx-glitch-duration', cfg.duration + 'ms');
+
+    if (cfg.type === 'slice') {
+      bindPowerGlitch(el, cfg);
+    }
+    // All other types are pure CSS — the [data-fx-glitch-type=...]
+    // selectors in neon-glitch.css handle :hover / :active.
+  }
+
+  function bindPowerGlitch(el, cfgArg) {
     if (el.dataset.pgBound === 'true') return;
     el.dataset.pgBound = 'true';
 
@@ -410,7 +450,7 @@
     el.addEventListener('mouseenter', function () {
       if (animating) return;
       animating = true;
-      var cfg = getGlitchConfig(el);
+      var cfg = cfgArg || getGlitchConfig(el);
       runPowerGlitch(el, cfg, function () {
         animating = false;
       });
@@ -544,18 +584,15 @@
       bindScramble(scrambleTargets[i]);
     }
 
-    // PowerGlitch buttons — JS slice port. Match anything that's a
-    // theme button or one of our standalone neon buttons carrying
-    // the glitch attribute. Non-button elements still get the
-    // CSS-only chromatic-aberration via the [data-fx-glitch]:hover
-    // keyframes in neon-glitch.css.
+    // Glitch targets — bindGlitch dispatches by type. For type
+    // 'slice' it kicks off the JS PowerGlitch port; for the other
+    // types it just stamps data-fx-glitch-type and the CSS keyframe
+    // selectors do the work.
     var glitchTargets = document.querySelectorAll(
-      '.button[data-fx-glitch]:not([data-pg-bound]),' +
-        '.ofx-neon-button[data-fx-glitch]:not([data-pg-bound]),' +
-        '.ofx-neon-button-fill[data-fx-glitch]:not([data-pg-bound])'
+      '[data-fx-glitch]:not([data-gl-bound])'
     );
     for (var g = 0; g < glitchTargets.length; g++) {
-      bindPowerGlitch(glitchTargets[g]);
+      bindGlitch(glitchTargets[g]);
     }
   }
 
@@ -587,6 +624,7 @@
   /* Expose for debugging / theme editor re-init */
   window.OmniFlexNeon = {
     bindScramble: bindScramble,
+    bindGlitch: bindGlitch,
     bindPowerGlitch: bindPowerGlitch,
     scan: scan,
   };

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -24,26 +24,82 @@
 
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
 
-  var GLITCH_CHARS = '▓▒░█▄▀■□◆◇▲▼►◄!@#$%^&*()_+={}[]|\\:;"<>?,./`~';
+  var DEFAULT_GLITCH_CHARS = '▓▒░█▄▀■□◆◇▲▼►◄!@#$%^&*()_+={}[]|\\:;"<>?,./`~';
+  var GLITCH_CHARSETS = {
+    mixed:   '▓▒░█▄▀■□◆◇▲▼►◄!@#$%^&*()_+={}[]|\\:;"<>?,./`~',
+    blocks:  '▓▒░█▄▀■□◆◇▲▼►◄',
+    symbols: '!@#$%^&*()_+={}[]|\\:;"<>?,./`~',
+    binary:  '01',
+    hex:     '0123456789ABCDEF',
+    katakana: 'アァカサタナハマヤラワガザダバパイィキシチニヒミリヰギジヂビピウゥクスツヌフムユルグズブヅプエェケセテネヘメレヱゲゼデベペオォコソトノホモヨロヲゴゾドボポヴッン',
+  };
+
   // Pulls live from the OmniFlex neon palette so merchant overrides in
   // theme settings flow through to the scramble flicker colors too.
-  var GLITCH_COLORS = [
+  var ROTATE_COLORS = [
     'var(--ofx-cyan)',
     'var(--ofx-pink)',
     'var(--ofx-purple)',
     'var(--ofx-magenta)',
   ];
+  var COLOR_VARS = {
+    cyan:    'var(--ofx-cyan)',
+    purple:  'var(--ofx-purple)',
+    magenta: 'var(--ofx-magenta)',
+    pink:    'var(--ofx-pink)',
+    green:   'var(--ofx-green)',
+    blue:    'var(--ofx-blue)',
+  };
 
-  function randomChar() {
-    return GLITCH_CHARS.charAt(Math.floor(Math.random() * GLITCH_CHARS.length));
+  function getScrambleConfig(el) {
+    // Walk up the DOM looking for the data attributes — they live on
+    // the bound element (the one with [data-scramble]), but the
+    // scrambler itself runs on the inner overlay. Default to the
+    // global config from theme.liquid.
+    var ds = el.dataset;
+    var globalCfg = (window.OmniFlexNeonConfig && window.OmniFlexNeonConfig.decode) || {};
+
+    var charsetName = ds.scrambleCharset || globalCfg.charset || 'mixed';
+    var charset = GLITCH_CHARSETS[charsetName] || DEFAULT_GLITCH_CHARS;
+
+    var colorMode = ds.scrambleColor || globalCfg.color || 'rotate';
+
+    var duration = parseInt(ds.scrambleDuration || globalCfg.duration, 10);
+    if (isNaN(duration) || duration <= 0) duration = 400;
+    // Internal "frame budget" scales with duration. Defaults are
+    // tuned for ~400ms; larger durations spread the scramble over
+    // proportionally more frames.
+    var frameScale = duration / 400;
+
+    return {
+      charset: charset,
+      colorMode: colorMode,
+      frameScale: frameScale,
+    };
   }
 
-  function randomColor() {
-    return GLITCH_COLORS[Math.floor(Math.random() * GLITCH_COLORS.length)];
+  function pickGlitchChar(cfg) {
+    return cfg.charset.charAt(Math.floor(Math.random() * cfg.charset.length));
   }
 
-  function TextScrambler(element) {
+  function pickGlitchColor(cfg, el) {
+    var mode = cfg.colorMode;
+    if (mode === 'rotate' || !mode) {
+      return ROTATE_COLORS[Math.floor(Math.random() * ROTATE_COLORS.length)];
+    }
+    if (mode === 'match') {
+      // Use the scrambling element's own rendered color.
+      return window.getComputedStyle(el).color;
+    }
+    if (COLOR_VARS[mode]) return COLOR_VARS[mode];
+    return mode; // raw CSS color string
+  }
+
+  function TextScrambler(element, hostElement) {
     this.el = element;
+    // hostElement is the [data-scramble]-tagged element where
+    // configuration lives — the overlay is a child of it.
+    this.host = hostElement || element;
     this.queue = [];
     this.frame = 0;
     this.frameRequest = null;
@@ -54,6 +110,8 @@
     var self = this;
     var oldText = this.el.textContent;
     var length = Math.max(oldText.length, newText.length);
+    this.cfg = getScrambleConfig(this.host);
+    var fs = this.cfg.frameScale;
     var promise = new Promise(function (resolve) {
       self.resolve = resolve;
     });
@@ -62,8 +120,8 @@
     for (var i = 0; i < length; i++) {
       var from = oldText[i] || '';
       var to = newText[i] || '';
-      var start = Math.floor(Math.random() * 8);
-      var end = start + Math.floor(Math.random() * 8) + 4;
+      var start = Math.floor(Math.random() * 8 * fs);
+      var end = start + Math.floor(Math.random() * 8 * fs) + Math.round(4 * fs);
       this.queue.push({ from: from, to: to, start: start, end: end });
     }
 
@@ -95,11 +153,11 @@
         fragment.appendChild(document.createTextNode(entry.to));
       } else if (this.frame >= entry.start) {
         if (!ch || Math.random() < 0.28) {
-          ch = randomChar();
+          ch = pickGlitchChar(this.cfg);
           entry.char = ch;
         }
         var span = document.createElement('span');
-        span.style.color = randomColor();
+        span.style.color = pickGlitchColor(this.cfg, this.host);
         span.appendChild(document.createTextNode(ch));
         fragment.appendChild(span);
       } else {
@@ -146,10 +204,26 @@
     overlay.setAttribute('aria-hidden', 'true');
     el.appendChild(overlay);
 
-    var scrambler = new TextScrambler(overlay);
+    var scrambler = new TextScrambler(overlay, el);
+    var animating = false;
+
+    // Replay mode: 'once' (default — fires the first hover then
+    // unbinds) or 'always' (re-fires every time the cursor enters).
+    // Per-element data-scramble-replay overrides the global setting.
+    function getReplayMode() {
+      if (el.dataset.scrambleReplay === 'always') return 'always';
+      if (el.dataset.scrambleReplay === 'once') return 'once';
+      var cfg = (window.OmniFlexNeonConfig && window.OmniFlexNeonConfig.decode) || {};
+      return cfg.replay === true || cfg.replay === 'always' ? 'always' : 'once';
+    }
 
     function onEnter() {
-      el.removeEventListener('mouseenter', onEnter);
+      if (animating) return;
+      animating = true;
+      var replayMode = getReplayMode();
+      if (replayMode === 'once') {
+        el.removeEventListener('mouseenter', onEnter);
+      }
 
       var finalText = textExcludingOverlay(el, overlay);
 
@@ -175,6 +249,7 @@
         el.classList.remove('is-scrambling');
         el.style.minWidth = originalMinWidth;
         el.style.display = originalDisplay;
+        animating = false;
       });
     }
 
@@ -266,23 +341,65 @@
    * animation duration so the bands appear to "slip" across the
    * button. Skips elements where prefers-reduced-motion is set.
    *
-   * Differences from the full library:
-   *   - Slice-only (no shake / hue-rotate); matches OmniTask's
-   *     POWERGLITCH_CONFIG which sets shake: false, hueRotate: false.
-   *   - Steps every ~33ms rather than per-frame so the slip reads as
-   *     a digital glitch, not a smooth motion.
-   *   - Skips a portion of frames during the last 40% of the
-   *     animation (matches glitchTimeSpan: { start: 0, end: 0.6 }).
+   * Configurable via window.OmniFlexNeonConfig.glitch (theme settings)
+   * and per-element data attributes:
+   *
+   *   data-fx-glitch-duration  ms (number)
+   *   data-fx-glitch-slices    1-8
+   *   data-fx-glitch-velocity  px (max horizontal offset)
+   *   data-fx-glitch-shake     "true" / "false"
+   *   data-fx-glitch-color     match | chromatic | cyan | purple |
+   *                            magenta | pink | green | blue
    */
-  var POWERGLITCH = {
-    sliceCount: 3,
-    duration: 400,
-    velocity: 18,
-    minHeight: 0.05,
-    maxHeight: 0.15,
-    glitchEnd: 0.6,
-    stepCount: 12,
+
+  // Hue-rotation angles applied via CSS filter. Approximate — the
+  // exact rendered tint depends on the button's source colors, but
+  // the relative shift is enough to push slices toward the chosen
+  // accent.
+  var HUE_ROTATIONS = {
+    cyan:    180,
+    blue:    220,
+    purple:  280,
+    magenta: 300,
+    pink:    320,
+    green:   100,
   };
+
+  function getGlitchConfig(el) {
+    var ds = el.dataset;
+    var globalCfg = (window.OmniFlexNeonConfig && window.OmniFlexNeonConfig.glitch) || {};
+
+    function pickInt(dsKey, globalKey, fallback) {
+      var raw = ds[dsKey];
+      if (raw != null && raw !== '') {
+        var n = parseInt(raw, 10);
+        if (!isNaN(n) && n > 0) return n;
+      }
+      var g = parseInt(globalCfg[globalKey], 10);
+      if (!isNaN(g) && g > 0) return g;
+      return fallback;
+    }
+
+    function pickBool(dsKey, globalKey, fallback) {
+      if (ds[dsKey] === 'true') return true;
+      if (ds[dsKey] === 'false') return false;
+      if (globalCfg[globalKey] === true) return true;
+      if (globalCfg[globalKey] === false) return false;
+      return fallback;
+    }
+
+    return {
+      sliceCount: pickInt('fxGlitchSlices', 'sliceCount', 3),
+      duration:   pickInt('fxGlitchDuration', 'duration', 400),
+      velocity:   pickInt('fxGlitchVelocity', 'velocity', 18),
+      minHeight:  0.05,
+      maxHeight:  0.15,
+      shake:      pickBool('fxGlitchShake', 'shake', false),
+      color:      ds.fxGlitchColor || globalCfg.color || 'match',
+      glitchEnd:  0.6,
+      stepCount:  12,
+    };
+  }
 
   function bindPowerGlitch(el) {
     if (el.dataset.pgBound === 'true') return;
@@ -293,16 +410,32 @@
     el.addEventListener('mouseenter', function () {
       if (animating) return;
       animating = true;
-      runPowerGlitch(el, function () {
+      var cfg = getGlitchConfig(el);
+      runPowerGlitch(el, cfg, function () {
         animating = false;
       });
     });
   }
 
-  function runPowerGlitch(el, onComplete) {
-    var cfg = POWERGLITCH;
+  function applySliceColor(slice, mode, idx) {
+    if (!mode || mode === 'match') return;
+    if (mode === 'chromatic') {
+      // Alternating cyan / magenta hue shifts — classic RGB
+      // chromatic-aberration look.
+      slice.style.filter = idx % 2 === 0 ? 'hue-rotate(90deg)' : 'hue-rotate(-90deg)';
+      slice.style.mixBlendMode = 'screen';
+      return;
+    }
+    var rotation = HUE_ROTATIONS[mode];
+    if (typeof rotation === 'number') {
+      slice.style.filter = 'hue-rotate(' + rotation + 'deg) saturate(1.4)';
+    }
+  }
+
+  function runPowerGlitch(el, cfg, onComplete) {
     var computed = window.getComputedStyle(el);
     var originalPosition = el.style.position;
+    var originalTransform = el.style.transform;
     if (computed.position === 'static') {
       el.style.position = 'relative';
     }
@@ -310,7 +443,8 @@
     // Build slice clones inside the original element.
     // Each clone is the full button laid on top, then clipped to a
     // band — so the slice color is whatever the button renders as
-    // (background + border + label all included).
+    // (background + border + label all included). When color !=
+    // 'match' a CSS filter is applied to tint the slice.
     var slices = [];
     for (var i = 0; i < cfg.sliceCount; i++) {
       var clone = el.cloneNode(true);
@@ -339,7 +473,8 @@
       clone.style.zIndex = '1';
       clone.style.clipPath = 'inset(100%)';
       clone.style.transform = 'translateX(0)';
-      clone.style.willChange = 'clip-path, transform';
+      clone.style.willChange = 'clip-path, transform, filter';
+      applySliceColor(clone, cfg.color, i);
       el.appendChild(clone);
       slices.push(clone);
     }
@@ -357,6 +492,7 @@
           if (slices[s].parentNode === el) el.removeChild(slices[s]);
         }
         el.style.position = originalPosition;
+        el.style.transform = originalTransform;
         if (onComplete) onComplete();
         return;
       }
@@ -379,6 +515,15 @@
             slices[i].style.clipPath = 'inset(' + insetTop + '% 0 ' + insetBottom + '% 0)';
             slices[i].style.transform = 'translateX(' + offsetX.toFixed(2) + 'px)';
           }
+        }
+
+        // Whole-element shake — matches OmniTask's optional
+        // shake: { velocity, ... } config. Velocity here is reused
+        // as the shake amplitude.
+        if (cfg.shake && inGlitchPhase) {
+          var sx = (Math.random() - 0.5) * 2 * (cfg.velocity * 0.4);
+          var sy = (Math.random() - 0.5) * 2 * (cfg.velocity * 0.25);
+          el.style.transform = 'translate(' + sx.toFixed(2) + 'px,' + sy.toFixed(2) + 'px)';
         }
       }
 

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -432,9 +432,9 @@
     //   1. Per-element data-fx-glitch-type
     //   2. Inherited from a parent (section wrapper etc.) carrying
     //      data-fx-glitch-type
-    //   3. Global config from theme settings
-    //   4. Default based on element kind (buttons -> slice,
-    //      otherwise chromatic-text)
+    //   3. Per-component-type default from theme settings
+    //      (typeButton / typeHeading / typeBox)
+    //   4. Hardcoded per-component-type fallback
     var type = ds.fxGlitchType;
     if (!type) {
       var ancestor = el.parentElement
@@ -442,13 +442,22 @@
         : null;
       if (ancestor) type = ancestor.getAttribute('data-fx-glitch-type');
     }
-    if (!type) type = globalCfg.type;
     if (!type) {
       var isButton =
         el.classList.contains('button') ||
         el.classList.contains('ofx-neon-button') ||
-        el.classList.contains('ofx-neon-button-fill');
-      type = isButton ? 'slice' : 'chromatic-text';
+        el.classList.contains('ofx-neon-button-fill') ||
+        el.tagName === 'BUTTON';
+      var tag = el.tagName;
+      var isHeading = tag === 'H1' || tag === 'H2' || tag === 'H3' ||
+                      tag === 'H4' || tag === 'H5' || tag === 'H6';
+      if (isButton) {
+        type = globalCfg.typeButton || 'slice';
+      } else if (isHeading) {
+        type = globalCfg.typeHeading || 'chromatic-text';
+      } else {
+        type = globalCfg.typeBox || 'chromatic-box';
+      }
     }
 
     return {
@@ -456,12 +465,12 @@
       sliceCount: pickInt('fxGlitchSlices', 'sliceCount', 3),
       duration:   pickInt('fxGlitchDuration', 'duration', 400),
       velocity:   pickInt('fxGlitchVelocity', 'velocity', 18),
+      stepCount:  pickInt('fxGlitchSteps', 'stepCount', 12),
       minHeight:  0.05,
       maxHeight:  0.15,
       shake:      pickBool('fxGlitchShake', 'shake', false),
       color:      ds.fxGlitchColor || globalCfg.color || 'match',
       glitchEnd:  0.6,
-      stepCount:  12,
     };
   }
 

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -195,7 +195,69 @@
     });
   }
 
+  /**
+   * Apply data attributes to elements matching merchant-supplied
+   * selectors (configured in Theme settings → Neon & glitch effects).
+   * Quietly skips invalid selectors so a typo can't kill the runtime
+   * for the rest of the page.
+   */
+  function applySelectorOptIns() {
+    var cfg = window.OmniFlexNeonConfig || {};
+
+    function tagAll(selector, attr) {
+      if (!selector) return;
+      try {
+        var matches = document.querySelectorAll(selector);
+        for (var i = 0; i < matches.length; i++) {
+          if (!matches[i].hasAttribute(attr)) {
+            matches[i].setAttribute(attr, '');
+          }
+        }
+      } catch (err) {
+        if (window.console && console.warn) {
+          console.warn('[OmniFlexNeon] Invalid selector "' + selector + '":', err);
+        }
+      }
+    }
+
+    // Comma-split so a merchant can list several selectors. Each is
+    // tried independently — one bad selector can't disable the rest.
+    var glitchSelectors = (cfg.glitchSelector || '').split(',');
+    for (var g = 0; g < glitchSelectors.length; g++) {
+      tagAll(glitchSelectors[g].trim(), 'data-fx-glitch');
+    }
+    var decodeSelectors = (cfg.decodeSelector || '').split(',');
+    for (var d = 0; d < decodeSelectors.length; d++) {
+      tagAll(decodeSelectors[d].trim(), 'data-scramble');
+    }
+
+    // Heading sweep — restricted to <main> so navigation / footer
+    // headings don't get the effect. Avoid clobbering elements that
+    // already carry an explicit data-scramble in markup.
+    if (cfg.decodeHeadings) {
+      var main = document.getElementById('MainContent') || document.querySelector('main');
+      if (main) {
+        var headings = main.querySelectorAll('h1, h2');
+        for (var h = 0; h < headings.length; h++) {
+          if (!headings[h].hasAttribute('data-scramble')) {
+            headings[h].setAttribute('data-scramble', '');
+          }
+        }
+      }
+    }
+
+    if (cfg.decodeButtons) {
+      var buttons = document.querySelectorAll('.button, .ofx-neon-button, .ofx-neon-button-fill');
+      for (var b = 0; b < buttons.length; b++) {
+        if (!buttons[b].hasAttribute('data-scramble')) {
+          buttons[b].setAttribute('data-scramble', '');
+        }
+      }
+    }
+  }
+
   function scan() {
+    applySelectorOptIns();
     var targets = document.querySelectorAll('[data-scramble]:not([data-scramble-bound])');
     for (var i = 0; i < targets.length; i++) {
       bindScramble(targets[i]);

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -1,0 +1,220 @@
+/**
+ * OmniFlex Neon & Glitch Effects — runtime
+ * Vanilla JS port of OmniTask's text-scrambler + glitch-fx orchestrator.
+ * No external dependencies. Self-initializes on DOMContentLoaded.
+ *
+ * Behaviors:
+ *   - Elements with [data-scramble] play a one-shot character-decode
+ *     animation the first time the cursor enters them. Subsequent
+ *     hovers do nothing — matches OmniTask's "decode on first reveal"
+ *     feel.
+ *   - The decode runs inside a sibling .scramble-overlay so the
+ *     element's real text node stays untouched (Liquid-rendered text
+ *     keeps its content; the original color/text-shadow are restored
+ *     after the animation).
+ *   - Bound elements get a data-scramble-bound sentinel so a
+ *     MutationObserver re-scan never double-binds.
+ *   - Skipped entirely under prefers-reduced-motion: reduce.
+ *
+ * Pure CSS handles the chromatic-aberration glitch on
+ * [data-fx-glitch]/[data-fx-glitch-box] — no JS needed for those.
+ */
+(function () {
+  'use strict';
+
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  var GLITCH_CHARS = '▓▒░█▄▀■□◆◇▲▼►◄!@#$%^&*()_+={}[]|\\:;"<>?,./`~';
+  var GLITCH_COLORS = ['#00d9ff', '#ff006e', '#b026ff', '#00fff5'];
+
+  function randomChar() {
+    return GLITCH_CHARS.charAt(Math.floor(Math.random() * GLITCH_CHARS.length));
+  }
+
+  function randomColor() {
+    return GLITCH_COLORS[Math.floor(Math.random() * GLITCH_COLORS.length)];
+  }
+
+  function TextScrambler(element) {
+    this.el = element;
+    this.queue = [];
+    this.frame = 0;
+    this.frameRequest = null;
+    this.resolve = null;
+  }
+
+  TextScrambler.prototype.setText = function (newText) {
+    var self = this;
+    var oldText = this.el.innerText;
+    var length = Math.max(oldText.length, newText.length);
+    var promise = new Promise(function (resolve) {
+      self.resolve = resolve;
+    });
+    this.queue = [];
+
+    for (var i = 0; i < length; i++) {
+      var from = oldText[i] || '';
+      var to = newText[i] || '';
+      var start = Math.floor(Math.random() * 8);
+      var end = start + Math.floor(Math.random() * 8) + 4;
+      this.queue.push({ from: from, to: to, start: start, end: end });
+    }
+
+    if (this.frameRequest !== null) {
+      cancelAnimationFrame(this.frameRequest);
+    }
+    this.frame = 0;
+    this.update();
+    return promise;
+  };
+
+  TextScrambler.prototype.update = function () {
+    var output = '';
+    var complete = 0;
+    var self = this;
+
+    for (var i = 0, n = this.queue.length; i < n; i++) {
+      var entry = this.queue[i];
+      var from = entry.from;
+      var to = entry.to;
+      var start = entry.start;
+      var end = entry.end;
+      var ch = entry.char;
+
+      if (this.frame >= end) {
+        complete++;
+        output += to;
+      } else if (this.frame >= start) {
+        if (!ch || Math.random() < 0.28) {
+          ch = randomChar();
+          entry.char = ch;
+        }
+        output += '<span style="color:' + randomColor() + '">' + ch + '</span>';
+      } else {
+        output += from;
+      }
+    }
+
+    this.el.innerHTML = output;
+
+    if (complete === this.queue.length) {
+      if (this.resolve) this.resolve();
+      this.frameRequest = null;
+    } else {
+      this.frameRequest = requestAnimationFrame(function () {
+        self.update();
+      });
+      this.frame++;
+    }
+  };
+
+  /**
+   * Read the element's text while ignoring the dedicated overlay,
+   * so the scrambler doesn't pick up the half-mutated overlay text
+   * as the next "from" state.
+   */
+  function textExcludingOverlay(el, overlay) {
+    var text = '';
+    el.childNodes.forEach(function (node) {
+      if (node === overlay) return;
+      text += node.textContent || '';
+    });
+    return text;
+  }
+
+  function bindScramble(el) {
+    if (el.dataset.scrambleBound === 'true') return;
+    el.dataset.scrambleBound = 'true';
+
+    var overlay = document.createElement('span');
+    overlay.className = 'scramble-overlay';
+    overlay.setAttribute('aria-hidden', 'true');
+    el.appendChild(overlay);
+
+    var scrambler = new TextScrambler(overlay);
+
+    function onEnter() {
+      el.removeEventListener('mouseenter', onEnter);
+
+      var finalText = textExcludingOverlay(el, overlay);
+
+      var rect = el.getBoundingClientRect();
+      var originalMinWidth = el.style.minWidth;
+      var originalDisplay = el.style.display;
+      var computed = window.getComputedStyle(el);
+      if (computed.display === 'inline') {
+        el.style.display = 'inline-block';
+      }
+      el.style.minWidth = Math.ceil(rect.width) + 'px';
+
+      overlay.style.color = computed.color;
+      overlay.style.textShadow = computed.textShadow;
+      overlay.textContent = finalText;
+
+      el.classList.add('is-scrambling');
+
+      scrambler.setText(finalText).then(function () {
+        overlay.textContent = '';
+        overlay.style.color = '';
+        overlay.style.textShadow = '';
+        el.classList.remove('is-scrambling');
+        el.style.minWidth = originalMinWidth;
+        el.style.display = originalDisplay;
+      });
+    }
+
+    el.addEventListener('mouseenter', onEnter);
+  }
+
+  /* ------- Observer-driven scanner ------- */
+
+  var observer = null;
+  var scanScheduled = false;
+
+  function scheduleScan() {
+    if (scanScheduled) return;
+    scanScheduled = true;
+    requestAnimationFrame(function () {
+      scanScheduled = false;
+      scan();
+    });
+  }
+
+  function scan() {
+    var targets = document.querySelectorAll('[data-scramble]:not([data-scramble-bound])');
+    for (var i = 0; i < targets.length; i++) {
+      bindScramble(targets[i]);
+    }
+  }
+
+  function init() {
+    if (observer) return;
+    var reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduced) return;
+
+    scan();
+
+    observer = new MutationObserver(function (mutations) {
+      for (var i = 0; i < mutations.length; i++) {
+        if (mutations[i].addedNodes.length > 0) {
+          scheduleScan();
+          return;
+        }
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  /* Expose for debugging / theme editor re-init */
+  window.OmniFlexNeon = {
+    bindScramble: bindScramble,
+    scan: scan,
+  };
+})();

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -256,11 +256,161 @@
     }
   }
 
+  /* ------- PowerGlitch port (vanilla JS) -------
+   *
+   * Reproduces the slice-and-displace look of OmniTask's powerglitch
+   * library (npm: powerglitch). On hover, the button is wrapped and N
+   * absolute-positioned clones are stacked on top. Each clone is
+   * clipped to a thin horizontal band via clip-path and translated
+   * horizontally by a random amount. Re-randomized in steps over the
+   * animation duration so the bands appear to "slip" across the
+   * button. Skips elements where prefers-reduced-motion is set.
+   *
+   * Differences from the full library:
+   *   - Slice-only (no shake / hue-rotate); matches OmniTask's
+   *     POWERGLITCH_CONFIG which sets shake: false, hueRotate: false.
+   *   - Steps every ~33ms rather than per-frame so the slip reads as
+   *     a digital glitch, not a smooth motion.
+   *   - Skips a portion of frames during the last 40% of the
+   *     animation (matches glitchTimeSpan: { start: 0, end: 0.6 }).
+   */
+  var POWERGLITCH = {
+    sliceCount: 3,
+    duration: 400,
+    velocity: 18,
+    minHeight: 0.05,
+    maxHeight: 0.15,
+    glitchEnd: 0.6,
+    stepCount: 12,
+  };
+
+  function bindPowerGlitch(el) {
+    if (el.dataset.pgBound === 'true') return;
+    el.dataset.pgBound = 'true';
+
+    var animating = false;
+
+    el.addEventListener('mouseenter', function () {
+      if (animating) return;
+      animating = true;
+      runPowerGlitch(el, function () {
+        animating = false;
+      });
+    });
+  }
+
+  function runPowerGlitch(el, onComplete) {
+    var cfg = POWERGLITCH;
+    var computed = window.getComputedStyle(el);
+    var originalPosition = el.style.position;
+    if (computed.position === 'static') {
+      el.style.position = 'relative';
+    }
+
+    // Build slice clones inside the original element.
+    // Each clone is the full button laid on top, then clipped to a
+    // band — so the slice color is whatever the button renders as
+    // (background + border + label all included).
+    var slices = [];
+    for (var i = 0; i < cfg.sliceCount; i++) {
+      var clone = el.cloneNode(true);
+      // Strip attributes that would cause re-binding or duplicate
+      // accessibility nodes.
+      clone.removeAttribute('id');
+      clone.removeAttribute('data-fx-glitch');
+      clone.removeAttribute('data-fx-glitch-hover');
+      clone.removeAttribute('data-fx-glitch-click');
+      clone.removeAttribute('data-fx-glitch-box');
+      clone.removeAttribute('data-scramble');
+      clone.removeAttribute('data-scramble-bound');
+      clone.removeAttribute('data-pg-bound');
+      clone.setAttribute('aria-hidden', 'true');
+      clone.setAttribute('tabindex', '-1');
+      clone.style.position = 'absolute';
+      clone.style.top = '0';
+      clone.style.left = '0';
+      clone.style.right = '0';
+      clone.style.bottom = '0';
+      clone.style.width = '100%';
+      clone.style.height = '100%';
+      clone.style.margin = '0';
+      clone.style.pointerEvents = 'none';
+      clone.style.userSelect = 'none';
+      clone.style.zIndex = '1';
+      clone.style.clipPath = 'inset(100%)';
+      clone.style.transform = 'translateX(0)';
+      clone.style.willChange = 'clip-path, transform';
+      el.appendChild(clone);
+      slices.push(clone);
+    }
+
+    var startTime = performance.now();
+    var stepDuration = cfg.duration / cfg.stepCount;
+    var lastStep = -1;
+
+    function tick(now) {
+      var elapsed = now - startTime;
+      var progress = elapsed / cfg.duration;
+
+      if (progress >= 1) {
+        for (var s = 0; s < slices.length; s++) {
+          if (slices[s].parentNode === el) el.removeChild(slices[s]);
+        }
+        el.style.position = originalPosition;
+        if (onComplete) onComplete();
+        return;
+      }
+
+      var step = Math.floor(elapsed / stepDuration);
+      if (step !== lastStep) {
+        lastStep = step;
+        var inGlitchPhase = progress < cfg.glitchEnd;
+        for (var i = 0; i < slices.length; i++) {
+          if (!inGlitchPhase || Math.random() < 0.18) {
+            // Hide this slice for this step — gives the stuttery feel
+            slices[i].style.clipPath = 'inset(100%)';
+            slices[i].style.transform = 'translateX(0)';
+          } else {
+            var top = Math.random();
+            var height = cfg.minHeight + Math.random() * (cfg.maxHeight - cfg.minHeight);
+            var offsetX = (Math.random() - 0.5) * 2 * cfg.velocity;
+            var insetTop = (top * 100).toFixed(2);
+            var insetBottom = Math.max(0, (1 - top - height) * 100).toFixed(2);
+            slices[i].style.clipPath = 'inset(' + insetTop + '% 0 ' + insetBottom + '% 0)';
+            slices[i].style.transform = 'translateX(' + offsetX.toFixed(2) + 'px)';
+          }
+        }
+      }
+
+      requestAnimationFrame(tick);
+    }
+
+    requestAnimationFrame(tick);
+  }
+
   function scan() {
     applySelectorOptIns();
-    var targets = document.querySelectorAll('[data-scramble]:not([data-scramble-bound])');
-    for (var i = 0; i < targets.length; i++) {
-      bindScramble(targets[i]);
+
+    // Decode/scramble targets
+    var scrambleTargets = document.querySelectorAll(
+      '[data-scramble]:not([data-scramble-bound])'
+    );
+    for (var i = 0; i < scrambleTargets.length; i++) {
+      bindScramble(scrambleTargets[i]);
+    }
+
+    // PowerGlitch buttons — JS slice port. Match anything that's a
+    // theme button or one of our standalone neon buttons carrying
+    // the glitch attribute. Non-button elements still get the
+    // CSS-only chromatic-aberration via the [data-fx-glitch]:hover
+    // keyframes in neon-glitch.css.
+    var glitchTargets = document.querySelectorAll(
+      '.button[data-fx-glitch]:not([data-pg-bound]),' +
+        '.ofx-neon-button[data-fx-glitch]:not([data-pg-bound]),' +
+        '.ofx-neon-button-fill[data-fx-glitch]:not([data-pg-bound])'
+    );
+    for (var g = 0; g < glitchTargets.length; g++) {
+      bindPowerGlitch(glitchTargets[g]);
     }
   }
 
@@ -292,6 +442,7 @@
   /* Expose for debugging / theme editor re-init */
   window.OmniFlexNeon = {
     bindScramble: bindScramble,
+    bindPowerGlitch: bindPowerGlitch,
     scan: scan,
   };
 })();

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -25,7 +25,14 @@
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
 
   var GLITCH_CHARS = '▓▒░█▄▀■□◆◇▲▼►◄!@#$%^&*()_+={}[]|\\:;"<>?,./`~';
-  var GLITCH_COLORS = ['#00d9ff', '#ff006e', '#b026ff', '#00fff5'];
+  // Pulls live from the OmniFlex neon palette so merchant overrides in
+  // theme settings flow through to the scramble flicker colors too.
+  var GLITCH_COLORS = [
+    'var(--ofx-cyan)',
+    'var(--ofx-pink)',
+    'var(--ofx-purple)',
+    'var(--ofx-magenta)',
+  ];
 
   function randomChar() {
     return GLITCH_CHARS.charAt(Math.floor(Math.random() * GLITCH_CHARS.length));
@@ -45,7 +52,7 @@
 
   TextScrambler.prototype.setText = function (newText) {
     var self = this;
-    var oldText = this.el.innerText;
+    var oldText = this.el.textContent;
     var length = Math.max(oldText.length, newText.length);
     var promise = new Promise(function (resolve) {
       self.resolve = resolve;
@@ -69,33 +76,41 @@
   };
 
   TextScrambler.prototype.update = function () {
-    var output = '';
     var complete = 0;
     var self = this;
+    // Build the next frame as a DocumentFragment composed of text nodes
+    // (for settled / unstarted glyphs) and color-tinted <span> elements
+    // (for actively scrambling glyphs). createTextNode escapes HTML by
+    // construction, so source characters like `<` or `&` cannot break
+    // out into markup — closes the XSS hole that the previous innerHTML
+    // path opened.
+    var fragment = document.createDocumentFragment();
 
     for (var i = 0, n = this.queue.length; i < n; i++) {
       var entry = this.queue[i];
-      var from = entry.from;
-      var to = entry.to;
-      var start = entry.start;
-      var end = entry.end;
       var ch = entry.char;
 
-      if (this.frame >= end) {
+      if (this.frame >= entry.end) {
         complete++;
-        output += to;
-      } else if (this.frame >= start) {
+        fragment.appendChild(document.createTextNode(entry.to));
+      } else if (this.frame >= entry.start) {
         if (!ch || Math.random() < 0.28) {
           ch = randomChar();
           entry.char = ch;
         }
-        output += '<span style="color:' + randomColor() + '">' + ch + '</span>';
+        var span = document.createElement('span');
+        span.style.color = randomColor();
+        span.appendChild(document.createTextNode(ch));
+        fragment.appendChild(span);
       } else {
-        output += from;
+        fragment.appendChild(document.createTextNode(entry.from));
       }
     }
 
-    this.el.innerHTML = output;
+    // Atomic replace: textContent='' clears children, then attach the
+    // fragment so the browser only paints once per animation frame.
+    this.el.textContent = '';
+    this.el.appendChild(fragment);
 
     if (complete === this.queue.length) {
       if (this.resolve) this.resolve();

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -623,8 +623,47 @@
     requestAnimationFrame(tick);
   }
 
+  /**
+   * Section-level activation. Any wrapper carrying
+   * data-fx-glitch-section="true" / data-scramble-section="true"
+   * promotes every neon button (or button label) inside it into a
+   * glitch / decode target, without the merchant having to flip the
+   * per-block toggle on each one. Idempotent: only stamps elements
+   * that don't already carry the attribute.
+   */
+  var BUTTON_SELECTOR =
+    '.button, .ofx-neon-button, .ofx-neon-button-fill, ' +
+    'button.shopify-payment-button__button--unbranded';
+
+  function applySectionActivation() {
+    var glitchSections = document.querySelectorAll(
+      '[data-fx-glitch-section="true"]'
+    );
+    for (var i = 0; i < glitchSections.length; i++) {
+      var buttons = glitchSections[i].querySelectorAll(BUTTON_SELECTOR);
+      for (var b = 0; b < buttons.length; b++) {
+        if (!buttons[b].hasAttribute('data-fx-glitch')) {
+          buttons[b].setAttribute('data-fx-glitch', '');
+        }
+      }
+    }
+
+    var decodeSections = document.querySelectorAll(
+      '[data-scramble-section="true"]'
+    );
+    for (var d = 0; d < decodeSections.length; d++) {
+      var labels = decodeSections[d].querySelectorAll(BUTTON_SELECTOR);
+      for (var L = 0; L < labels.length; L++) {
+        if (!labels[L].hasAttribute('data-scramble')) {
+          labels[L].setAttribute('data-scramble', '');
+        }
+      }
+    }
+  }
+
   function scan() {
     applySelectorOptIns();
+    applySectionActivation();
 
     // Decode/scramble targets
     var scrambleTargets = document.querySelectorAll(

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -34,9 +34,11 @@
     katakana: 'アァカサタナハマヤラワガザダバパイィキシチニヒミリヰギジヂビピウゥクスツヌフムユルグズブヅプエェケセテネヘメレヱゲゼデベペオォコソトノホモヨロヲゴゾドボポヴッン',
   };
 
-  // Pulls live from the OmniFlex neon palette so merchant overrides in
-  // theme settings flow through to the scramble flicker colors too.
-  var ROTATE_COLORS = [
+  // Default rotation when no scheme overrides --ofx-decode-color-*.
+  // When a section's color scheme defines those CSS vars, the
+  // scrambler uses those instead so the glyph colors automatically
+  // match whichever Shopify scheme is active.
+  var DEFAULT_ROTATE_COLORS = [
     'var(--ofx-cyan)',
     'var(--ofx-pink)',
     'var(--ofx-purple)',
@@ -51,20 +53,41 @@
     blue:    'var(--ofx-blue)',
   };
 
+  /**
+   * Walk up the DOM (starting at parentElement so the element's own
+   * attribute is excluded) looking for an ancestor data-* attribute.
+   * Returns the value as a string, or undefined if not found.
+   */
+  function inheritedAttr(el, attr) {
+    if (!el.parentElement) return undefined;
+    var ancestor = el.parentElement.closest('[' + attr + ']');
+    return ancestor ? ancestor.getAttribute(attr) : undefined;
+  }
+
   function getScrambleConfig(el) {
-    // Walk up the DOM looking for the data attributes — they live on
-    // the bound element (the one with [data-scramble]), but the
-    // scrambler itself runs on the inner overlay. Default to the
-    // global config from theme.liquid.
     var ds = el.dataset;
     var globalCfg = (window.OmniFlexNeonConfig && window.OmniFlexNeonConfig.decode) || {};
 
-    var charsetName = ds.scrambleCharset || globalCfg.charset || 'mixed';
+    // Cascade for each setting: per-element attr -> inherited from
+    // ancestor -> global config -> built-in default.
+    var charsetName =
+      ds.scrambleCharset ||
+      inheritedAttr(el, 'data-scramble-charset') ||
+      globalCfg.charset ||
+      'mixed';
     var charset = GLITCH_CHARSETS[charsetName] || DEFAULT_GLITCH_CHARS;
 
-    var colorMode = ds.scrambleColor || globalCfg.color || 'rotate';
+    var colorMode =
+      ds.scrambleColor ||
+      inheritedAttr(el, 'data-scramble-color') ||
+      globalCfg.color ||
+      'rotate';
 
-    var duration = parseInt(ds.scrambleDuration || globalCfg.duration, 10);
+    var durationRaw =
+      ds.scrambleDuration ||
+      inheritedAttr(el, 'data-scramble-duration') ||
+      globalCfg.duration;
+    var duration = parseInt(durationRaw, 10);
     if (isNaN(duration) || duration <= 0) duration = 400;
     // Internal "frame budget" scales with duration. Defaults are
     // tuned for ~400ms; larger durations spread the scramble over
@@ -82,10 +105,27 @@
     return cfg.charset.charAt(Math.floor(Math.random() * cfg.charset.length));
   }
 
+  /**
+   * Read the --ofx-decode-color-N CSS variables off the element and
+   * return any non-empty values as a list. Lets the active Shopify
+   * scheme drive the rotation colors without per-element JS config.
+   * Falls back to the OmniTask cyan/pink/purple/magenta defaults.
+   */
+  function rotateColorsFor(el) {
+    var styles = window.getComputedStyle(el);
+    var colors = [];
+    for (var i = 1; i <= 4; i++) {
+      var v = styles.getPropertyValue('--ofx-decode-color-' + i).trim();
+      if (v) colors.push(v);
+    }
+    return colors.length > 0 ? colors : DEFAULT_ROTATE_COLORS;
+  }
+
   function pickGlitchColor(cfg, el) {
     var mode = cfg.colorMode;
     if (mode === 'rotate' || !mode) {
-      return ROTATE_COLORS[Math.floor(Math.random() * ROTATE_COLORS.length)];
+      var colors = rotateColorsFor(el);
+      return colors[Math.floor(Math.random() * colors.length)];
     }
     if (mode === 'match') {
       // Use the scrambling element's own rendered color.
@@ -388,11 +428,21 @@
       return fallback;
     }
 
-    // Resolve the glitch type. Per-element data-fx-glitch-type wins,
-    // then global config, then a sensible default based on the
-    // element kind: buttons get the slice (PowerGlitch), everything
-    // else gets the chromatic-text variant.
-    var type = ds.fxGlitchType || globalCfg.type;
+    // Resolve the glitch type. Cascade order, highest first:
+    //   1. Per-element data-fx-glitch-type
+    //   2. Inherited from a parent (section wrapper etc.) carrying
+    //      data-fx-glitch-type
+    //   3. Global config from theme settings
+    //   4. Default based on element kind (buttons -> slice,
+    //      otherwise chromatic-text)
+    var type = ds.fxGlitchType;
+    if (!type) {
+      var ancestor = el.parentElement
+        ? el.parentElement.closest('[data-fx-glitch-type]')
+        : null;
+      if (ancestor) type = ancestor.getAttribute('data-fx-glitch-type');
+    }
+    if (!type) type = globalCfg.type;
     if (!type) {
       var isButton =
         el.classList.contains('button') ||

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -614,6 +614,10 @@
       clone.removeAttribute('data-pg-bound');
       clone.setAttribute('aria-hidden', 'true');
       clone.setAttribute('tabindex', '-1');
+      // Marker so neon-glitch.css can hide Dawn's ::before sweep
+      // gradient + ::after ring on clones — those pseudo-elements are
+      // decorative chrome that interfere with the slice illusion.
+      clone.setAttribute('data-pg-slice', 'true');
       clone.style.position = 'absolute';
       clone.style.top = '0';
       clone.style.left = '0';

--- a/assets/neon-glitch.js
+++ b/assets/neon-glitch.js
@@ -362,11 +362,24 @@
     }
 
     if (cfg.decodeButtons) {
-      var buttons = document.querySelectorAll('.button, .ofx-neon-button, .ofx-neon-button-fill');
+      var buttons = document.querySelectorAll('.button, .ofx-neon-button, .ofx-neon-button-fill, .omni-glitch-btn');
       for (var b = 0; b < buttons.length; b++) {
         if (!buttons[b].hasAttribute('data-scramble')) {
           buttons[b].setAttribute('data-scramble', '');
         }
+      }
+    }
+
+    // OmniTask's exact opt-in class — auto-tag for slice glitch so
+    // merchants can drop the same class name from OmniTask onto any
+    // element and get the same effect.
+    var omniTargets = document.querySelectorAll(
+      '.omni-glitch-btn:not([data-fx-glitch])'
+    );
+    for (var o = 0; o < omniTargets.length; o++) {
+      omniTargets[o].setAttribute('data-fx-glitch', '');
+      if (!omniTargets[o].hasAttribute('data-fx-glitch-type')) {
+        omniTargets[o].setAttribute('data-fx-glitch-type', 'slice');
       }
     }
   }
@@ -447,6 +460,7 @@
         el.classList.contains('button') ||
         el.classList.contains('ofx-neon-button') ||
         el.classList.contains('ofx-neon-button-fill') ||
+        el.classList.contains('omni-glitch-btn') ||
         el.tagName === 'BUTTON';
       var tag = el.tagName;
       var isHeading = tag === 'H1' || tag === 'H2' || tag === 'H3' ||
@@ -460,17 +474,36 @@
       }
     }
 
+    function pickPercent(dsKey, globalKey, fallback) {
+      var raw = ds[dsKey];
+      if (raw != null && raw !== '') {
+        var n = parseFloat(raw);
+        if (!isNaN(n)) return n / 100;
+      }
+      var g = parseFloat(globalCfg[globalKey]);
+      if (!isNaN(g)) return g / 100;
+      return fallback;
+    }
+
+    var trigger = ds.fxGlitchTrigger || globalCfg.trigger || 'hover';
+    if (trigger !== 'hover' && trigger !== 'click' && trigger !== 'both') {
+      trigger = 'hover';
+    }
+
     return {
       type:       type,
       sliceCount: pickInt('fxGlitchSlices', 'sliceCount', 3),
       duration:   pickInt('fxGlitchDuration', 'duration', 400),
+      iterations: pickInt('fxGlitchIterations', 'iterations', 1),
+      trigger:    trigger,
       velocity:   pickInt('fxGlitchVelocity', 'velocity', 18),
       stepCount:  pickInt('fxGlitchSteps', 'stepCount', 12),
-      minHeight:  0.05,
-      maxHeight:  0.15,
+      minHeight:  pickPercent('fxGlitchSliceMin', 'sliceMin', 0.05),
+      maxHeight:  pickPercent('fxGlitchSliceMax', 'sliceMax', 0.15),
+      glitchStart: pickPercent('fxGlitchStart', 'glitchStart', 0),
+      glitchEnd:  pickPercent('fxGlitchEnd', 'glitchEnd', 0.6),
       shake:      pickBool('fxGlitchShake', 'shake', false),
       color:      ds.fxGlitchColor || globalCfg.color || 'match',
-      glitchEnd:  0.6,
     };
   }
 
@@ -506,14 +539,36 @@
 
     var animating = false;
 
-    el.addEventListener('mouseenter', function () {
+    function trigger() {
       if (animating) return;
       animating = true;
       var cfg = cfgArg || getGlitchConfig(el);
-      runPowerGlitch(el, cfg, function () {
-        animating = false;
+      var iterations = Math.max(1, cfg.iterations || 1);
+      var remaining = iterations;
+
+      function runOnce() {
+        runPowerGlitch(el, cfg, function () {
+          remaining--;
+          if (remaining > 0) {
+            runOnce();
+          } else {
+            animating = false;
+          }
+        });
+      }
+      runOnce();
+    }
+
+    var triggerMode = (cfgArg || getGlitchConfig(el)).trigger || 'hover';
+    if (triggerMode === 'hover' || triggerMode === 'both') {
+      el.addEventListener('mouseenter', trigger);
+    }
+    if (triggerMode === 'click' || triggerMode === 'both') {
+      el.addEventListener('mousedown', trigger);
+      el.addEventListener('keydown', function (ev) {
+        if (ev.key === 'Enter' || ev.key === ' ') trigger();
       });
-    });
+    }
   }
 
   function applySliceColor(slice, mode, idx) {
@@ -599,7 +654,7 @@
       var step = Math.floor(elapsed / stepDuration);
       if (step !== lastStep) {
         lastStep = step;
-        var inGlitchPhase = progress < cfg.glitchEnd;
+        var inGlitchPhase = progress >= (cfg.glitchStart || 0) && progress < cfg.glitchEnd;
         for (var i = 0; i < slices.length; i++) {
           if (!inGlitchPhase || Math.random() < 0.18) {
             // Hide this slice for this step — gives the stuttery feel

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -249,15 +249,59 @@
           "shadow": "#000000"
         }
       },
-      "scheme-omnitask": {
+      "scheme-omnitask-cyan": {
         "settings": {
           "background": "#0a0f1e",
           "background_gradient": "linear-gradient(180deg, rgba(5, 8, 16, 0.92) 0%, rgba(10, 20, 60, 0.75) 50%, rgba(15, 30, 80, 0.65) 100%)",
           "text": "#f0f6ff",
           "button": "#00d2ff",
           "button_label": "#050810",
-          "secondary_button_label": "#e040fb",
+          "secondary_button_label": "#00d2ff",
           "shadow": "#00d2ff"
+        }
+      },
+      "scheme-omnitask-purple": {
+        "settings": {
+          "background": "#0a0f1e",
+          "background_gradient": "linear-gradient(180deg, rgba(5, 8, 16, 0.92) 0%, rgba(20, 8, 50, 0.75) 50%, rgba(30, 12, 70, 0.65) 100%)",
+          "text": "#f0f6ff",
+          "button": "#e040fb",
+          "button_label": "#050810",
+          "secondary_button_label": "#e040fb",
+          "shadow": "#e040fb"
+        }
+      },
+      "scheme-omnitask-magenta": {
+        "settings": {
+          "background": "#0a0f1e",
+          "background_gradient": "linear-gradient(180deg, rgba(5, 8, 16, 0.92) 0%, rgba(40, 5, 50, 0.75) 50%, rgba(60, 8, 70, 0.65) 100%)",
+          "text": "#f0f6ff",
+          "button": "#d500f9",
+          "button_label": "#050810",
+          "secondary_button_label": "#d500f9",
+          "shadow": "#d500f9"
+        }
+      },
+      "scheme-omnitask-pink": {
+        "settings": {
+          "background": "#100612",
+          "background_gradient": "linear-gradient(180deg, rgba(15, 5, 20, 0.92) 0%, rgba(50, 6, 30, 0.75) 50%, rgba(70, 10, 40, 0.65) 100%)",
+          "text": "#f0f6ff",
+          "button": "#ff1493",
+          "button_label": "#050810",
+          "secondary_button_label": "#ff1493",
+          "shadow": "#ff1493"
+        }
+      },
+      "scheme-omnitask-green": {
+        "settings": {
+          "background": "#06110b",
+          "background_gradient": "linear-gradient(180deg, rgba(5, 16, 10, 0.92) 0%, rgba(8, 35, 20, 0.75) 50%, rgba(12, 50, 28, 0.65) 100%)",
+          "text": "#f0f6ff",
+          "button": "#8ce696",
+          "button_label": "#050810",
+          "secondary_button_label": "#8ce696",
+          "shadow": "#8ce696"
         }
       }
     }

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -248,6 +248,17 @@
           "secondary_button_label": "#ffffff",
           "shadow": "#000000"
         }
+      },
+      "scheme-omnitask": {
+        "settings": {
+          "background": "#0a0f1e",
+          "background_gradient": "linear-gradient(180deg, rgba(5, 8, 16, 0.92) 0%, rgba(10, 20, 60, 0.75) 50%, rgba(15, 30, 80, 0.65) 100%)",
+          "text": "#f0f6ff",
+          "button": "#00d2ff",
+          "button_label": "#050810",
+          "secondary_button_label": "#e040fb",
+          "shadow": "#00d2ff"
+        }
       }
     }
   },

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1658,6 +1658,28 @@
       },
       {
         "type": "range",
+        "id": "neon_glitch_iterations",
+        "label": "Iterations per trigger",
+        "info": "How many times the glitch repeats on a single hover/click. Matches OmniTask's PowerGlitch `iterations` (default 1 = one-shot).",
+        "min": 1,
+        "max": 6,
+        "step": 1,
+        "default": 1
+      },
+      {
+        "type": "select",
+        "id": "neon_glitch_trigger",
+        "label": "Trigger mode (slice type)",
+        "info": "When the slice/PowerGlitch effect fires. 'Hover' matches OmniTask's PowerGlitch playMode. The other glitch types (chromatic, shake, flicker, rgb-split) always fire on both hover and click via CSS.",
+        "options": [
+          { "value": "hover", "label": "Hover only (OmniTask default)" },
+          { "value": "click", "label": "Click only" },
+          { "value": "both", "label": "Hover + click" }
+        ],
+        "default": "hover"
+      },
+      {
+        "type": "range",
         "id": "neon_glitch_step_count",
         "label": "Step granularity (slice type only)",
         "info": "How many discrete random slice configurations the animation cycles through. Higher = grainier / more digital.",
@@ -1690,6 +1712,50 @@
         "step": 2,
         "unit": "px",
         "default": 18
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_slice_min",
+        "label": "Slice min height",
+        "info": "Smallest height (% of button) a slice can take. Maps to OmniTask's `slice.minHeight`.",
+        "min": 1,
+        "max": 25,
+        "step": 1,
+        "unit": "%",
+        "default": 5
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_slice_max",
+        "label": "Slice max height",
+        "info": "Largest height (% of button) a slice can take. Maps to OmniTask's `slice.maxHeight`.",
+        "min": 5,
+        "max": 60,
+        "step": 1,
+        "unit": "%",
+        "default": 15
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_start",
+        "label": "Glitch phase start",
+        "info": "Point in the animation (% of duration) when slices first appear. Maps to OmniTask's `glitchTimeSpan.start`.",
+        "min": 0,
+        "max": 80,
+        "step": 5,
+        "unit": "%",
+        "default": 0
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_end",
+        "label": "Glitch phase end",
+        "info": "Point in the animation (% of duration) when slices stop and the button settles. Maps to OmniTask's `glitchTimeSpan.end` (default 60%).",
+        "min": 20,
+        "max": 100,
+        "step": 5,
+        "unit": "%",
+        "default": 60
       },
       {
         "type": "checkbox",
@@ -1771,6 +1837,58 @@
         "label": "Replay decode on every hover",
         "info": "Off (default) plays the decode once per page load. On replays it whenever the cursor enters the element.",
         "default": false
+      },
+      {
+        "type": "header",
+        "content": "Neon glow strength"
+      },
+      {
+        "type": "paragraph",
+        "content": "Multipliers applied to every neon halo and pulse. Increase for a more saturated, in-your-face neon; decrease for a subtler glow."
+      },
+      {
+        "type": "range",
+        "id": "neon_glow_intensity",
+        "label": "Outer glow intensity",
+        "info": "Scales the box-shadow radius of every neon button and bordered element. 100% = OmniTask default.",
+        "min": 25,
+        "max": 250,
+        "step": 5,
+        "unit": "%",
+        "default": 100
+      },
+      {
+        "type": "range",
+        "id": "neon_text_glow_intensity",
+        "label": "Text glow intensity",
+        "info": "Scales the text-shadow halo on .text-neon, neon button labels, and the flickering text utility.",
+        "min": 25,
+        "max": 250,
+        "step": 5,
+        "unit": "%",
+        "default": 100
+      },
+      {
+        "type": "range",
+        "id": "neon_pulse_speed",
+        "label": "Pulse speed (.cyber-pulse)",
+        "info": "Cycle length of the pulsing glow used by .cyber-pulse and .cyber-active. Lower = faster.",
+        "min": 500,
+        "max": 5000,
+        "step": 100,
+        "unit": "ms",
+        "default": 2000
+      },
+      {
+        "type": "range",
+        "id": "neon_flicker_speed",
+        "label": "Text flicker speed (.text-neon-flicker)",
+        "info": "Cycle length of the text-flicker animation. Lower = faster pulse.",
+        "min": 500,
+        "max": 6000,
+        "step": 100,
+        "unit": "ms",
+        "default": 3000
       },
       {
         "type": "header",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1590,6 +1590,125 @@
       },
       {
         "type": "header",
+        "content": "Glitch (PowerGlitch) animation"
+      },
+      {
+        "type": "paragraph",
+        "content": "Tunes the chromatic-aberration slice effect on button hover. Per-button overrides on the section blocks beat these defaults."
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_duration",
+        "label": "Duration (ms)",
+        "min": 100,
+        "max": 2000,
+        "step": 50,
+        "unit": "ms",
+        "default": 400
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_slice_count",
+        "label": "Slice count",
+        "info": "Number of horizontal slices the button breaks into per glitch frame.",
+        "min": 1,
+        "max": 8,
+        "step": 1,
+        "default": 3
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_velocity",
+        "label": "Slice displacement",
+        "info": "Maximum horizontal offset (in pixels) applied to each slice per step.",
+        "min": 4,
+        "max": 60,
+        "step": 2,
+        "unit": "px",
+        "default": 18
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_glitch_shake",
+        "label": "Shake the whole button while slicing",
+        "info": "Adds OmniTask's shake mode on top of the slice effect. Off matches the default OmniTask config.",
+        "default": false
+      },
+      {
+        "type": "select",
+        "id": "neon_glitch_color",
+        "label": "Slice color source",
+        "info": "How slices are tinted. 'Match button' is a clean clone (default). 'Chromatic aberration' splits slices into RGB ghosts. The named colors apply a hue-rotation toward that color.",
+        "options": [
+          { "value": "match", "label": "Match button color" },
+          { "value": "chromatic", "label": "Chromatic aberration (RGB split)" },
+          { "value": "cyan", "label": "Cyan" },
+          { "value": "purple", "label": "Purple" },
+          { "value": "magenta", "label": "Magenta" },
+          { "value": "pink", "label": "Pink" },
+          { "value": "green", "label": "Green" },
+          { "value": "blue", "label": "Blue" }
+        ],
+        "default": "match"
+      },
+      {
+        "type": "header",
+        "content": "Decode (text scramble) animation"
+      },
+      {
+        "type": "paragraph",
+        "content": "Tunes the character-scramble decode effect. Per-element data-scramble-* attributes beat these defaults."
+      },
+      {
+        "type": "range",
+        "id": "neon_decode_duration",
+        "label": "Duration (ms)",
+        "info": "Approximate total time for all characters to settle. Longer = slower decode.",
+        "min": 100,
+        "max": 2000,
+        "step": 50,
+        "unit": "ms",
+        "default": 400
+      },
+      {
+        "type": "select",
+        "id": "neon_decode_color",
+        "label": "Glyph color source",
+        "options": [
+          { "value": "rotate", "label": "Rotate (cyan / pink / purple / magenta)" },
+          { "value": "match", "label": "Match the element's own color" },
+          { "value": "cyan", "label": "Cyan" },
+          { "value": "purple", "label": "Purple" },
+          { "value": "magenta", "label": "Magenta" },
+          { "value": "pink", "label": "Pink" },
+          { "value": "green", "label": "Green" },
+          { "value": "blue", "label": "Blue" }
+        ],
+        "default": "rotate"
+      },
+      {
+        "type": "select",
+        "id": "neon_decode_charset",
+        "label": "Glyph set",
+        "options": [
+          { "value": "mixed", "label": "Mixed (blocks + symbols, OmniTask default)" },
+          { "value": "blocks", "label": "Block characters" },
+          { "value": "symbols", "label": "Symbols / punctuation" },
+          { "value": "binary", "label": "Binary (0 / 1)" },
+          { "value": "hex", "label": "Hexadecimal" },
+          { "value": "katakana", "label": "Katakana (Matrix-style)" }
+        ],
+        "default": "mixed"
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_decode_replay",
+        "label": "Replay decode on every hover",
+        "info": "Off (default) plays the decode once per page load. On replays it whenever the cursor enters the element.",
+        "default": false
+      },
+      {
+        "type": "header",
         "content": "Color palette"
       },
       {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1516,6 +1516,10 @@
     "name": "Neon & glitch effects",
     "settings": [
       {
+        "type": "paragraph",
+        "content": "Every parameter below is a default that flows through the whole storefront. Glitch and decode colors automatically match the active section's color scheme, so picking one of the scheme-omnitask-cyan / -purple / -magenta / -pink / -green schemes is usually enough to get a tuned look on its own. Sections expose 'Apply glitch / decode to all buttons' toggles to switch the effect on without re-configuring each block."
+      },
+      {
         "type": "header",
         "content": "Global toggles"
       },
@@ -1594,13 +1598,13 @@
       },
       {
         "type": "paragraph",
-        "content": "Choose the default glitch effect that fires on button hover. Per-button overrides on the section blocks beat these defaults."
+        "content": "Defaults for every element with a glitch effect. Glitch slices and chromatic ghosts automatically match the active Shopify color scheme's primary button color, so picking a scheme is usually all the configuration a section needs."
       },
       {
         "type": "select",
-        "id": "neon_glitch_type",
-        "label": "Glitch type",
-        "info": "Slice = OmniTask's PowerGlitch port (DOM clones cut into bands). Chromatic = CSS keyframes that ghost the element into RGB shadows. Shake / Flicker / RGB split are simpler standalone effects.",
+        "id": "neon_glitch_type_button",
+        "label": "Glitch type — buttons",
+        "info": "Default effect on .button / neon button hover. Slice is OmniTask's PowerGlitch port (DOM clones cut into bands).",
         "options": [
           { "value": "slice", "label": "Slice (PowerGlitch)" },
           { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
@@ -1612,6 +1616,36 @@
         "default": "slice"
       },
       {
+        "type": "select",
+        "id": "neon_glitch_type_heading",
+        "label": "Glitch type — headings",
+        "info": "Default for h1 / h2 / h3 with [data-fx-glitch].",
+        "options": [
+          { "value": "slice", "label": "Slice (PowerGlitch)" },
+          { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
+          { "value": "chromatic-box", "label": "Chromatic — box ghosts" },
+          { "value": "rgb-split", "label": "RGB split (heavier chromatic)" },
+          { "value": "shake", "label": "Shake" },
+          { "value": "flicker", "label": "Flicker" }
+        ],
+        "default": "chromatic-text"
+      },
+      {
+        "type": "select",
+        "id": "neon_glitch_type_box",
+        "label": "Glitch type — cards & other elements",
+        "info": "Catch-all default for non-button, non-heading targets (cards, icons, etc.). Box variants use drop-shadow filters instead of text-shadow so the chromatic ghosts wrap the whole rectangle.",
+        "options": [
+          { "value": "slice", "label": "Slice (PowerGlitch)" },
+          { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
+          { "value": "chromatic-box", "label": "Chromatic — box ghosts" },
+          { "value": "rgb-split", "label": "RGB split (heavier chromatic)" },
+          { "value": "shake", "label": "Shake" },
+          { "value": "flicker", "label": "Flicker" }
+        ],
+        "default": "chromatic-box"
+      },
+      {
         "type": "range",
         "id": "neon_glitch_duration",
         "label": "Duration (ms)",
@@ -1621,6 +1655,16 @@
         "step": 50,
         "unit": "ms",
         "default": 400
+      },
+      {
+        "type": "range",
+        "id": "neon_glitch_step_count",
+        "label": "Step granularity (slice type only)",
+        "info": "How many discrete random slice configurations the animation cycles through. Higher = grainier / more digital.",
+        "min": 4,
+        "max": 24,
+        "step": 1,
+        "default": 12
       },
       {
         "type": "paragraph",
@@ -1657,10 +1701,10 @@
       {
         "type": "select",
         "id": "neon_glitch_color",
-        "label": "Slice color source",
-        "info": "How slices are tinted. 'Match button' is a clean clone (default). 'Chromatic aberration' splits slices into RGB ghosts. The named colors apply a hue-rotation toward that color.",
+        "label": "Glitch color source",
+        "info": "Default tint for glitch slices and chromatic ghosts. 'Match scheme primary button' is the recommended default — slices reuse the active section's primary button color, so each scheme automatically themes its own glitch. The named colors force a specific neon hue regardless of scheme.",
         "options": [
-          { "value": "match", "label": "Match button color" },
+          { "value": "match", "label": "Match scheme primary button (recommended)" },
           { "value": "chromatic", "label": "Chromatic aberration (RGB split)" },
           { "value": "cyan", "label": "Cyan" },
           { "value": "purple", "label": "Purple" },
@@ -1677,7 +1721,7 @@
       },
       {
         "type": "paragraph",
-        "content": "Tunes the character-scramble decode effect. Per-element data-scramble-* attributes beat these defaults."
+        "content": "Defaults for the character-scramble decode. The 'Rotate' color mode automatically picks from the active scheme's neon palette so each section's decode glyphs match its theme."
       },
       {
         "type": "range",
@@ -1694,8 +1738,9 @@
         "type": "select",
         "id": "neon_decode_color",
         "label": "Glyph color source",
+        "info": "Rotate uses the active section's scheme palette automatically. Match copies the element's own rendered color (so decoded glyphs stay the button label color).",
         "options": [
-          { "value": "rotate", "label": "Rotate (cyan / pink / purple / magenta)" },
+          { "value": "rotate", "label": "Rotate scheme palette (recommended)" },
           { "value": "match", "label": "Match the element's own color" },
           { "value": "cyan", "label": "Cyan" },
           { "value": "purple", "label": "Purple" },

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1590,21 +1590,41 @@
       },
       {
         "type": "header",
-        "content": "Glitch (PowerGlitch) animation"
+        "content": "Glitch animation"
       },
       {
         "type": "paragraph",
-        "content": "Tunes the chromatic-aberration slice effect on button hover. Per-button overrides on the section blocks beat these defaults."
+        "content": "Choose the default glitch effect that fires on button hover. Per-button overrides on the section blocks beat these defaults."
+      },
+      {
+        "type": "select",
+        "id": "neon_glitch_type",
+        "label": "Glitch type",
+        "info": "Slice = OmniTask's PowerGlitch port (DOM clones cut into bands). Chromatic = CSS keyframes that ghost the element into RGB shadows. Shake / Flicker / RGB split are simpler standalone effects.",
+        "options": [
+          { "value": "slice", "label": "Slice (PowerGlitch)" },
+          { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
+          { "value": "chromatic-box", "label": "Chromatic — box ghosts" },
+          { "value": "rgb-split", "label": "RGB split (heavier chromatic)" },
+          { "value": "shake", "label": "Shake" },
+          { "value": "flicker", "label": "Flicker" }
+        ],
+        "default": "slice"
       },
       {
         "type": "range",
         "id": "neon_glitch_duration",
         "label": "Duration (ms)",
+        "info": "Total animation length. All glitch types respect this.",
         "min": 100,
         "max": 2000,
         "step": 50,
         "unit": "ms",
         "default": 400
+      },
+      {
+        "type": "paragraph",
+        "content": "The settings below only apply to the Slice (PowerGlitch) type."
       },
       {
         "type": "range",

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1554,6 +1554,42 @@
       },
       {
         "type": "header",
+        "content": "Per-element opt-in"
+      },
+      {
+        "type": "paragraph",
+        "content": "Apply effects to specific elements anywhere on the storefront via CSS selectors. JS auto-tags matching elements with the data attributes. Comma-separate multiple selectors."
+      },
+      {
+        "type": "text",
+        "id": "neon_glitch_selector",
+        "label": "Glitch on hover — CSS selectors",
+        "info": "Examples: .shopify-section-template--16-image-banner .button--primary, .product-form__submit, [data-cta='hero']",
+        "default": ""
+      },
+      {
+        "type": "text",
+        "id": "neon_decode_selector",
+        "label": "Decode on first hover — CSS selectors",
+        "info": "Examples: .banner__heading, h1.title, .featured-product__title",
+        "default": ""
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_decode_headings",
+        "label": "Auto-decode H1 / H2 in main content",
+        "info": "Adds the decode/scramble effect to every H1 and H2 inside section blocks (skips header/footer/menus).",
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_decode_buttons",
+        "label": "Auto-decode all theme button labels",
+        "info": "Decodes button text on first hover. Skipped automatically when 'Reduce motion' is set in the OS.",
+        "default": false
+      },
+      {
+        "type": "header",
         "content": "Color palette"
       },
       {

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1511,5 +1511,91 @@
         "unit": "%"
       }
     ]
+  },
+  {
+    "name": "Neon & glitch effects",
+    "settings": [
+      {
+        "type": "header",
+        "content": "Global toggles"
+      },
+      {
+        "type": "paragraph",
+        "content": "Brings OmniTask's cyberpunk styling into the storefront. Enable per-effect or apply to every theme button at once."
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_global_buttons",
+        "label": "Apply neon glow to all theme buttons",
+        "info": "Replaces the default fill / outline buttons with the OmniTask neon look (filled for primary, outline for secondary).",
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_global_glitch",
+        "label": "Glitch animation on every button hover/click",
+        "info": "Chromatic-aberration flicker on hover, harder burst on click. Skips automatically when the visitor has Reduce Motion on.",
+        "default": false
+      },
+      {
+        "type": "select",
+        "id": "neon_default_color",
+        "label": "Default neon color",
+        "info": "Sets --ofx-neon-rgb at the document root so any element using neon classes picks up this color by default.",
+        "options": [
+          { "value": "", "label": "Cyan (default)" },
+          { "value": "purple", "label": "Purple" },
+          { "value": "magenta", "label": "Magenta" },
+          { "value": "pink", "label": "Pink" },
+          { "value": "green", "label": "Green" },
+          { "value": "blue", "label": "Blue" }
+        ],
+        "default": ""
+      },
+      {
+        "type": "header",
+        "content": "Color palette"
+      },
+      {
+        "type": "paragraph",
+        "content": "Override the OmniTask palette to match your brand. Leave blank to keep the defaults."
+      },
+      {
+        "type": "color",
+        "id": "neon_color_cyan",
+        "label": "Cyan",
+        "default": "#00d2ff"
+      },
+      {
+        "type": "color",
+        "id": "neon_color_purple",
+        "label": "Purple",
+        "default": "#e040fb"
+      },
+      {
+        "type": "color",
+        "id": "neon_color_magenta",
+        "label": "Magenta",
+        "default": "#d500f9"
+      },
+      {
+        "type": "color",
+        "id": "neon_color_pink",
+        "label": "Pink",
+        "default": "#ff1493"
+      },
+      {
+        "type": "color",
+        "id": "neon_color_green",
+        "label": "Green",
+        "default": "#8ce696"
+      },
+      {
+        "type": "color",
+        "id": "neon_color_blue",
+        "label": "Blue",
+        "default": "#50beff"
+      }
+    ]
   }
 ]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -406,12 +406,15 @@
         {%- endif -%}
 
         {%- if settings.neon_global_glitch -%}
-          /* Hover/active chromatic-aberration glitch on all theme buttons. */
+          /* PowerGlitch-style slice on every theme button. The box
+             keyframes use drop-shadow filters so the whole rectangle
+             slices into chromatic-aberration ghosts (rather than just
+             the text). One run per hover — does not loop. */
           .button:not([disabled]):hover {
-            animation: ofx-fx-glitch-hover 0.45s steps(12, end);
+            animation: ofx-fx-glitch-box-hover 0.45s steps(12, end);
           }
           .button:not([disabled]):active {
-            animation: ofx-fx-glitch-click 0.32s steps(14, end);
+            animation: ofx-fx-glitch-box-click 0.32s steps(14, end);
           }
           @media (prefers-reduced-motion: reduce) {
             .button:not([disabled]):hover,

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -34,6 +34,14 @@
     <script src="{{ 'details-disclosure.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'details-modal.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'search-form.js' | asset_url }}" defer="defer"></script>
+    <script>
+      window.OmniFlexNeonConfig = {
+        glitchSelector: {{ settings.neon_glitch_selector | default: '' | json }},
+        decodeSelector: {{ settings.neon_decode_selector | default: '' | json }},
+        decodeHeadings: {{ settings.neon_decode_headings | default: false | json }},
+        decodeButtons: {{ settings.neon_decode_buttons | default: false | json }}
+      };
+    </script>
     <script src="{{ 'neon-glitch.js' | asset_url }}" defer="defer"></script>
 
     {%- if settings.animations_reveal_on_scroll -%}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -384,7 +384,14 @@
     {%- if settings.neon_global_buttons or settings.neon_global_glitch -%}
       <style>
         {%- if settings.neon_global_buttons -%}
-          /* Apply neon glow to every theme button while keeping Dawn's box model. */
+          /* Apply neon glow to every theme button while keeping Dawn's
+             box model. !important is required throughout because Dawn's
+             .animate--hover-3d-lift / .animate--hover-vertical-lift
+             rules carry higher selector specificity (0,4,1) than ours
+             and would otherwise wipe the glow + transform on hover.
+             Dawn's :focus-visible accessibility ring also overrides
+             box-shadow, so the focus rules below reassert the glow and
+             use outline (which Dawn zeroes) for the a11y ring. */
           .button--primary,
           .shopify-payment-button__button--unbranded {
             position: relative;
@@ -395,9 +402,14 @@
             box-shadow:
               0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
               0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
-              inset 0 0 8px rgba(255, 255, 255, 0.15);
+              inset 0 0 8px rgba(255, 255, 255, 0.15) !important;
             transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
             overflow: hidden;
+          }
+          .button--primary::before,
+          .shopify-payment-button__button--unbranded::before,
+          .button--secondary::before {
+            box-shadow: none !important;
           }
           .button--primary::after,
           .shopify-payment-button__button--unbranded::after {
@@ -409,8 +421,19 @@
             box-shadow:
               0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
               0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
-              inset 0 0 12px rgba(255, 255, 255, 0.25);
-            transform: translateY(-1px);
+              inset 0 0 12px rgba(255, 255, 255, 0.25) !important;
+            transform: translateY(-1px) !important;
+          }
+          .button--primary:focus-visible,
+          .button--primary:focus,
+          .shopify-payment-button__button--unbranded:focus-visible,
+          .shopify-payment-button__button--unbranded:focus {
+            outline: 2px solid rgb(var(--ofx-neon-rgb));
+            outline-offset: 3px;
+            box-shadow:
+              0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
+              0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
+              inset 0 0 12px rgba(255, 255, 255, 0.25) !important;
           }
           .button--secondary {
             position: relative;
@@ -421,7 +444,7 @@
             box-shadow:
               0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
               0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
-              inset 0 0 12px rgba(var(--ofx-neon-rgb), 0.08);
+              inset 0 0 12px rgba(var(--ofx-neon-rgb), 0.08) !important;
             transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
             overflow: hidden;
           }
@@ -431,8 +454,17 @@
             box-shadow:
               0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
               0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
-              inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18);
-            transform: translateY(-1px);
+              inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18) !important;
+            transform: translateY(-1px) !important;
+          }
+          .button--secondary:focus-visible,
+          .button--secondary:focus {
+            outline: 2px solid rgb(var(--ofx-neon-rgb));
+            outline-offset: 3px;
+            box-shadow:
+              0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
+              0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
+              inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18) !important;
           }
         {%- endif -%}
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -41,10 +41,13 @@
         decodeHeadings: {{ settings.neon_decode_headings | default: false | json }},
         decodeButtons: {{ settings.neon_decode_buttons | default: false | json }},
         glitch: {
-          type: {{ settings.neon_glitch_type | default: 'slice' | json }},
+          typeButton: {{ settings.neon_glitch_type_button | default: 'slice' | json }},
+          typeHeading: {{ settings.neon_glitch_type_heading | default: 'chromatic-text' | json }},
+          typeBox: {{ settings.neon_glitch_type_box | default: 'chromatic-box' | json }},
           duration: {{ settings.neon_glitch_duration | default: 400 | json }},
           sliceCount: {{ settings.neon_glitch_slice_count | default: 3 | json }},
           velocity: {{ settings.neon_glitch_velocity | default: 18 | json }},
+          stepCount: {{ settings.neon_glitch_step_count | default: 12 | json }},
           shake: {{ settings.neon_glitch_shake | default: false | json }},
           color: {{ settings.neon_glitch_color | default: 'match' | json }}
         },

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -39,7 +39,20 @@
         glitchSelector: {{ settings.neon_glitch_selector | default: '' | json }},
         decodeSelector: {{ settings.neon_decode_selector | default: '' | json }},
         decodeHeadings: {{ settings.neon_decode_headings | default: false | json }},
-        decodeButtons: {{ settings.neon_decode_buttons | default: false | json }}
+        decodeButtons: {{ settings.neon_decode_buttons | default: false | json }},
+        glitch: {
+          duration: {{ settings.neon_glitch_duration | default: 400 | json }},
+          sliceCount: {{ settings.neon_glitch_slice_count | default: 3 | json }},
+          velocity: {{ settings.neon_glitch_velocity | default: 18 | json }},
+          shake: {{ settings.neon_glitch_shake | default: false | json }},
+          color: {{ settings.neon_glitch_color | default: 'match' | json }}
+        },
+        decode: {
+          duration: {{ settings.neon_decode_duration | default: 400 | json }},
+          color: {{ settings.neon_decode_color | default: 'rotate' | json }},
+          charset: {{ settings.neon_decode_charset | default: 'mixed' | json }},
+          replay: {{ settings.neon_decode_replay | default: false | json }}
+        }
       };
     </script>
     <script src="{{ 'neon-glitch.js' | asset_url }}" defer="defer"></script>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -45,9 +45,15 @@
           typeHeading: {{ settings.neon_glitch_type_heading | default: 'chromatic-text' | json }},
           typeBox: {{ settings.neon_glitch_type_box | default: 'chromatic-box' | json }},
           duration: {{ settings.neon_glitch_duration | default: 400 | json }},
+          iterations: {{ settings.neon_glitch_iterations | default: 1 | json }},
+          trigger: {{ settings.neon_glitch_trigger | default: 'hover' | json }},
           sliceCount: {{ settings.neon_glitch_slice_count | default: 3 | json }},
           velocity: {{ settings.neon_glitch_velocity | default: 18 | json }},
           stepCount: {{ settings.neon_glitch_step_count | default: 12 | json }},
+          sliceMin: {{ settings.neon_glitch_slice_min | default: 5 | json }},
+          sliceMax: {{ settings.neon_glitch_slice_max | default: 15 | json }},
+          glitchStart: {{ settings.neon_glitch_start | default: 0 | json }},
+          glitchEnd: {{ settings.neon_glitch_end | default: 60 | json }},
           shake: {{ settings.neon_glitch_shake | default: false | json }},
           color: {{ settings.neon_glitch_color | default: 'match' | json }}
         },
@@ -332,40 +338,48 @@
       Per-color overrides feed into assets/neon-glitch.css via CSS variables.
       Added by Claude Code.
     {%- endcomment -%}
-    {%- if settings.neon_color_cyan or settings.neon_color_purple or settings.neon_color_magenta or settings.neon_color_pink or settings.neon_color_green or settings.neon_color_blue or settings.neon_default_color != blank -%}
-      <style>
-        :root {
-          {%- if settings.neon_color_cyan != blank -%}
-            --ofx-cyan: {{ settings.neon_color_cyan }};
-            --ofx-cyan-rgb: {{ settings.neon_color_cyan.red }}, {{ settings.neon_color_cyan.green }}, {{ settings.neon_color_cyan.blue }};
-          {%- endif -%}
-          {%- if settings.neon_color_purple != blank -%}
-            --ofx-purple: {{ settings.neon_color_purple }};
-            --ofx-purple-rgb: {{ settings.neon_color_purple.red }}, {{ settings.neon_color_purple.green }}, {{ settings.neon_color_purple.blue }};
-          {%- endif -%}
-          {%- if settings.neon_color_magenta != blank -%}
-            --ofx-magenta: {{ settings.neon_color_magenta }};
-            --ofx-magenta-rgb: {{ settings.neon_color_magenta.red }}, {{ settings.neon_color_magenta.green }}, {{ settings.neon_color_magenta.blue }};
-          {%- endif -%}
-          {%- if settings.neon_color_pink != blank -%}
-            --ofx-pink: {{ settings.neon_color_pink }};
-            --ofx-pink-rgb: {{ settings.neon_color_pink.red }}, {{ settings.neon_color_pink.green }}, {{ settings.neon_color_pink.blue }};
-          {%- endif -%}
-          {%- if settings.neon_color_green != blank -%}
-            --ofx-green: {{ settings.neon_color_green }};
-            --ofx-green-rgb: {{ settings.neon_color_green.red }}, {{ settings.neon_color_green.green }}, {{ settings.neon_color_green.blue }};
-          {%- endif -%}
-          {%- if settings.neon_color_blue != blank -%}
-            --ofx-blue: {{ settings.neon_color_blue }};
-            --ofx-blue-rgb: {{ settings.neon_color_blue.red }}, {{ settings.neon_color_blue.green }}, {{ settings.neon_color_blue.blue }};
-          {%- endif -%}
-          {%- if settings.neon_default_color != blank -%}
-            --ofx-neon-rgb: var(--ofx-{{ settings.neon_default_color }}-rgb);
-            --ofx-neon: rgb(var(--ofx-neon-rgb));
-          {%- endif -%}
-        }
-      </style>
-    {%- endif -%}
+    {%- liquid
+      assign neon_glow = settings.neon_glow_intensity | default: 100 | divided_by: 100.0
+      assign neon_text_glow = settings.neon_text_glow_intensity | default: 100 | divided_by: 100.0
+      assign neon_pulse_speed = settings.neon_pulse_speed | default: 2000
+      assign neon_flicker_speed = settings.neon_flicker_speed | default: 3000
+    -%}
+    <style>
+      :root {
+        {%- if settings.neon_color_cyan != blank -%}
+          --ofx-cyan: {{ settings.neon_color_cyan }};
+          --ofx-cyan-rgb: {{ settings.neon_color_cyan.red }}, {{ settings.neon_color_cyan.green }}, {{ settings.neon_color_cyan.blue }};
+        {%- endif -%}
+        {%- if settings.neon_color_purple != blank -%}
+          --ofx-purple: {{ settings.neon_color_purple }};
+          --ofx-purple-rgb: {{ settings.neon_color_purple.red }}, {{ settings.neon_color_purple.green }}, {{ settings.neon_color_purple.blue }};
+        {%- endif -%}
+        {%- if settings.neon_color_magenta != blank -%}
+          --ofx-magenta: {{ settings.neon_color_magenta }};
+          --ofx-magenta-rgb: {{ settings.neon_color_magenta.red }}, {{ settings.neon_color_magenta.green }}, {{ settings.neon_color_magenta.blue }};
+        {%- endif -%}
+        {%- if settings.neon_color_pink != blank -%}
+          --ofx-pink: {{ settings.neon_color_pink }};
+          --ofx-pink-rgb: {{ settings.neon_color_pink.red }}, {{ settings.neon_color_pink.green }}, {{ settings.neon_color_pink.blue }};
+        {%- endif -%}
+        {%- if settings.neon_color_green != blank -%}
+          --ofx-green: {{ settings.neon_color_green }};
+          --ofx-green-rgb: {{ settings.neon_color_green.red }}, {{ settings.neon_color_green.green }}, {{ settings.neon_color_green.blue }};
+        {%- endif -%}
+        {%- if settings.neon_color_blue != blank -%}
+          --ofx-blue: {{ settings.neon_color_blue }};
+          --ofx-blue-rgb: {{ settings.neon_color_blue.red }}, {{ settings.neon_color_blue.green }}, {{ settings.neon_color_blue.blue }};
+        {%- endif -%}
+        {%- if settings.neon_default_color != blank -%}
+          --ofx-neon-rgb: var(--ofx-{{ settings.neon_default_color }}-rgb);
+          --ofx-neon: rgb(var(--ofx-neon-rgb));
+        {%- endif -%}
+        --ofx-glow-intensity: {{ neon_glow }};
+        --ofx-text-glow-intensity: {{ neon_text_glow }};
+        --ofx-pulse-duration: {{ neon_pulse_speed }}ms;
+        --ofx-flicker-duration: {{ neon_flicker_speed }}ms;
+      }
+    </style>
 
     {%- if settings.neon_global_buttons or settings.neon_global_glitch -%}
       <style>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -34,6 +34,7 @@
     <script src="{{ 'details-disclosure.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'details-modal.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'search-form.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'neon-glitch.js' | asset_url }}" defer="defer"></script>
 
     {%- if settings.animations_reveal_on_scroll -%}
       <script src="{{ 'animations.js' | asset_url }}" defer="defer"></script>
@@ -256,6 +257,7 @@
     {% endstyle %}
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
+    {{ 'neon-glitch.css' | asset_url | stylesheet_tag }}
     <link rel="stylesheet" href="{{ 'component-cart-items.css' | asset_url }}" media="print" onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}
@@ -301,6 +303,119 @@
     </script>
 
     {%- comment -%}
+      OmniFlex: Neon palette + global glitch/decode toggles.
+      Per-color overrides feed into assets/neon-glitch.css via CSS variables.
+      Added by Claude Code.
+    {%- endcomment -%}
+    {%- if settings.neon_color_cyan or settings.neon_color_purple or settings.neon_color_magenta or settings.neon_color_pink or settings.neon_color_green or settings.neon_color_blue or settings.neon_default_color != blank -%}
+      <style>
+        :root {
+          {%- if settings.neon_color_cyan != blank -%}
+            --ofx-cyan: {{ settings.neon_color_cyan }};
+            --ofx-cyan-rgb: {{ settings.neon_color_cyan.red }}, {{ settings.neon_color_cyan.green }}, {{ settings.neon_color_cyan.blue }};
+          {%- endif -%}
+          {%- if settings.neon_color_purple != blank -%}
+            --ofx-purple: {{ settings.neon_color_purple }};
+            --ofx-purple-rgb: {{ settings.neon_color_purple.red }}, {{ settings.neon_color_purple.green }}, {{ settings.neon_color_purple.blue }};
+          {%- endif -%}
+          {%- if settings.neon_color_magenta != blank -%}
+            --ofx-magenta: {{ settings.neon_color_magenta }};
+            --ofx-magenta-rgb: {{ settings.neon_color_magenta.red }}, {{ settings.neon_color_magenta.green }}, {{ settings.neon_color_magenta.blue }};
+          {%- endif -%}
+          {%- if settings.neon_color_pink != blank -%}
+            --ofx-pink: {{ settings.neon_color_pink }};
+            --ofx-pink-rgb: {{ settings.neon_color_pink.red }}, {{ settings.neon_color_pink.green }}, {{ settings.neon_color_pink.blue }};
+          {%- endif -%}
+          {%- if settings.neon_color_green != blank -%}
+            --ofx-green: {{ settings.neon_color_green }};
+            --ofx-green-rgb: {{ settings.neon_color_green.red }}, {{ settings.neon_color_green.green }}, {{ settings.neon_color_green.blue }};
+          {%- endif -%}
+          {%- if settings.neon_color_blue != blank -%}
+            --ofx-blue: {{ settings.neon_color_blue }};
+            --ofx-blue-rgb: {{ settings.neon_color_blue.red }}, {{ settings.neon_color_blue.green }}, {{ settings.neon_color_blue.blue }};
+          {%- endif -%}
+          {%- if settings.neon_default_color != blank -%}
+            --ofx-neon-rgb: var(--ofx-{{ settings.neon_default_color }}-rgb);
+            --ofx-neon: rgb(var(--ofx-neon-rgb));
+          {%- endif -%}
+        }
+      </style>
+    {%- endif -%}
+
+    {%- if settings.neon_global_buttons or settings.neon_global_glitch -%}
+      <style>
+        {%- if settings.neon_global_buttons -%}
+          /* Apply neon glow to every theme button while keeping Dawn's box model. */
+          .button--primary,
+          .shopify-payment-button__button--unbranded {
+            position: relative;
+            border: 2px solid rgb(var(--ofx-neon-rgb)) !important;
+            background-color: rgba(var(--ofx-neon-rgb), 0.85) !important;
+            color: #050810 !important;
+            text-shadow: 0 0 6px rgba(255, 255, 255, 0.6);
+            box-shadow:
+              0 0 12px rgba(var(--ofx-neon-rgb), 0.5),
+              0 0 28px rgba(var(--ofx-neon-rgb), 0.3),
+              inset 0 0 8px rgba(255, 255, 255, 0.15);
+            transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
+            overflow: hidden;
+          }
+          .button--primary::after,
+          .shopify-payment-button__button--unbranded::after {
+            box-shadow: none !important;
+          }
+          .button--primary:not([disabled]):hover,
+          .shopify-payment-button__button--unbranded:not([disabled]):hover {
+            background-color: rgba(var(--ofx-neon-rgb), 1) !important;
+            box-shadow:
+              0 0 22px rgba(var(--ofx-neon-rgb), 0.8),
+              0 0 44px rgba(var(--ofx-neon-rgb), 0.45),
+              inset 0 0 12px rgba(255, 255, 255, 0.25);
+            transform: translateY(-1px);
+          }
+          .button--secondary {
+            position: relative;
+            border: 2px solid rgb(var(--ofx-neon-rgb)) !important;
+            background-color: rgba(var(--ofx-neon-rgb), 0.08) !important;
+            color: rgb(var(--ofx-neon-rgb)) !important;
+            text-shadow: 0 0 10px rgba(var(--ofx-neon-rgb), 0.7);
+            box-shadow:
+              0 0 10px rgba(var(--ofx-neon-rgb), 0.3),
+              0 0 20px rgba(var(--ofx-neon-rgb), 0.1),
+              inset 0 0 12px rgba(var(--ofx-neon-rgb), 0.08);
+            transition: box-shadow 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
+            overflow: hidden;
+          }
+          .button--secondary::after { box-shadow: none !important; }
+          .button--secondary:not([disabled]):hover {
+            background-color: rgba(var(--ofx-neon-rgb), 0.16) !important;
+            box-shadow:
+              0 0 18px rgba(var(--ofx-neon-rgb), 0.6),
+              0 0 34px rgba(var(--ofx-neon-rgb), 0.3),
+              inset 0 0 18px rgba(var(--ofx-neon-rgb), 0.18);
+            transform: translateY(-1px);
+          }
+        {%- endif -%}
+
+        {%- if settings.neon_global_glitch -%}
+          /* Hover/active chromatic-aberration glitch on all theme buttons. */
+          .button:not([disabled]):hover {
+            animation: ofx-fx-glitch-hover 0.45s steps(12, end);
+          }
+          .button:not([disabled]):active {
+            animation: ofx-fx-glitch-click 0.32s steps(14, end);
+          }
+          @media (prefers-reduced-motion: reduce) {
+            .button:not([disabled]):hover,
+            .button:not([disabled]):active {
+              animation: none !important;
+            }
+          }
+        {%- endif -%}
+      </style>
+    {%- endif -%}
+
+    {%- comment -%}
       OmniFlex: Global background image controlled via Theme Settings → Background.
       Added by Claude Code.
     {%- endcomment -%}
@@ -331,7 +446,7 @@
     {%- endif -%}
   </head>
 
-  <body class="gradient template-{{ request.page_type | handle }}{% if request.page_type == 'page' %}-{{ page.handle }}{% endif %}{% if settings.animations_hover_elements != 'none' %} animate--hover-{{ settings.animations_hover_elements }}{% endif %}">
+  <body class="gradient template-{{ request.page_type | handle }}{% if request.page_type == 'page' %}-{{ page.handle }}{% endif %}{% if settings.animations_hover_elements != 'none' %} animate--hover-{{ settings.animations_hover_elements }}{% endif %}{% if settings.neon_global_buttons or settings.neon_global_glitch or settings.neon_default_color != blank %} neon-active{% endif %}">
     <a class="skip-to-content-link button visually-hidden" href="#MainContent">
       {{ 'accessibility.skip_to_text' | t }}
     </a>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -41,6 +41,7 @@
         decodeHeadings: {{ settings.neon_decode_headings | default: false | json }},
         decodeButtons: {{ settings.neon_decode_buttons | default: false | json }},
         glitch: {
+          type: {{ settings.neon_glitch_type | default: 'slice' | json }},
           duration: {{ settings.neon_glitch_duration | default: 400 | json }},
           sliceCount: {{ settings.neon_glitch_slice_count | default: 3 | json }},
           velocity: {{ settings.neon_glitch_velocity | default: 18 | json }},

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -116,7 +116,17 @@
     </div>
   {%- endif -%}
   <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
-    <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient">
+    {%- liquid
+      assign banner_inline_style = ''
+      if section.settings.section_glitch_duration > 0
+        assign banner_inline_style = banner_inline_style | append: '--ofx-glitch-duration:' | append: section.settings.section_glitch_duration | append: 'ms;'
+      endif
+    -%}
+    <div
+      class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient"
+      {% if section.settings.section_glitch_type != blank %}data-fx-glitch-type="{{ section.settings.section_glitch_type }}"{% endif %}
+      {% if banner_inline_style != blank %}style="{{ banner_inline_style }}"{% endif %}
+    >
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when 'heading' -%}
@@ -329,7 +339,38 @@
       "type": "color_scheme",
       "id": "color_scheme",
       "label": "t:sections.all.colors.label",
+      "info": "Pick scheme-omnitask-cyan / -purple / -magenta / -pink / -green for tuned glitch + decode colors out of the box.",
       "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "Glitch defaults for buttons in this section"
+    },
+    {
+      "type": "select",
+      "id": "section_glitch_type",
+      "label": "Glitch type",
+      "info": "Applied to any button in this section that has 'Glitch on hover/click' enabled. Per-button overrides still win.",
+      "options": [
+        { "value": "", "label": "Inherit from theme settings" },
+        { "value": "slice", "label": "Slice (PowerGlitch)" },
+        { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
+        { "value": "chromatic-box", "label": "Chromatic — box ghosts" },
+        { "value": "rgb-split", "label": "RGB split (heavier chromatic)" },
+        { "value": "shake", "label": "Shake" },
+        { "value": "flicker", "label": "Flicker" }
+      ],
+      "default": ""
+    },
+    {
+      "type": "range",
+      "id": "section_glitch_duration",
+      "label": "Glitch duration",
+      "min": 0,
+      "max": 2000,
+      "step": 50,
+      "unit": "ms",
+      "default": 0
     },
     {
       "type": "header",

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -116,16 +116,11 @@
     </div>
   {%- endif -%}
   <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
-    {%- liquid
-      assign banner_inline_style = ''
-      if section.settings.section_glitch_duration > 0
-        assign banner_inline_style = banner_inline_style | append: '--ofx-glitch-duration:' | append: section.settings.section_glitch_duration | append: 'ms;'
-      endif
-    -%}
     <div
       class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient"
+      {% if section.settings.section_apply_glitch %}data-fx-glitch-section="true"{% endif %}
+      {% if section.settings.section_apply_decode %}data-scramble-section="true"{% endif %}
       {% if section.settings.section_glitch_type != blank %}data-fx-glitch-type="{{ section.settings.section_glitch_type }}"{% endif %}
-      {% if banner_inline_style != blank %}style="{{ banner_inline_style }}"{% endif %}
     >
       {%- for block in section.blocks -%}
         {%- case block.type -%}
@@ -344,13 +339,29 @@
     },
     {
       "type": "header",
-      "content": "Glitch defaults for buttons in this section"
+      "content": "Activate effects for this section"
+    },
+    {
+      "type": "paragraph",
+      "content": "Apply the global glitch / decode effects to every button in this section in one click — duration, slice count and other parameters live in Theme settings → Neon & glitch effects."
+    },
+    {
+      "type": "checkbox",
+      "id": "section_apply_glitch",
+      "label": "Apply glitch to all buttons in this section",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "section_apply_decode",
+      "label": "Apply decode to all button labels in this section",
+      "default": false
     },
     {
       "type": "select",
       "id": "section_glitch_type",
-      "label": "Glitch type",
-      "info": "Applied to any button in this section that has 'Glitch on hover/click' enabled. Per-button overrides still win.",
+      "label": "Glitch type override (optional)",
+      "info": "Leave on Inherit to use the global Glitch type from theme settings.",
       "options": [
         { "value": "", "label": "Inherit from theme settings" },
         { "value": "slice", "label": "Slice (PowerGlitch)" },
@@ -361,16 +372,6 @@
         { "value": "flicker", "label": "Flicker" }
       ],
       "default": ""
-    },
-    {
-      "type": "range",
-      "id": "section_glitch_duration",
-      "label": "Glitch duration",
-      "min": 0,
-      "max": 2000,
-      "step": 50,
-      "unit": "ms",
-      "default": 0
     },
     {
       "type": "header",

--- a/sections/image-banner.liquid
+++ b/sections/image-banner.liquid
@@ -135,6 +135,10 @@
               class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_label_2 != blank %} banner__buttons--multiple{% endif %}"
               {{ block.shopify_attributes }}
             >
+              {%- liquid
+                assign neon_color_1 = block.settings.neon_color_1 | default: ''
+                assign neon_color_2 = block.settings.neon_color_2 | default: ''
+              -%}
               {%- if block.settings.button_label_1 != blank -%}
                 <a
                   {% if block.settings.button_link_1 == blank %}
@@ -142,7 +146,9 @@
                   {% else %}
                     href="{{ block.settings.button_link_1 }}"
                   {% endif %}
-                  class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"
+                  class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}{% if block.settings.neon_style_1 == 'outline' %} button--neon{% elsif block.settings.neon_style_1 == 'fill' %} button--neon-fill{% endif %}{% if neon_color_1 != blank %} button--neon--{{ neon_color_1 }}{% endif %}"
+                  {% if block.settings.button_glitch_1 %}data-fx-glitch{% endif %}
+                  {% if block.settings.button_decode_1 %}data-scramble{% endif %}
                 >
                   {{- block.settings.button_label_1 | escape -}}
                 </a>
@@ -154,7 +160,9 @@
                   {% else %}
                     href="{{ block.settings.button_link_2 }}"
                   {% endif %}
-                  class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"
+                  class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}{% if block.settings.neon_style_2 == 'outline' %} button--neon{% elsif block.settings.neon_style_2 == 'fill' %} button--neon-fill{% endif %}{% if neon_color_2 != blank %} button--neon--{{ neon_color_2 }}{% endif %}"
+                  {% if block.settings.button_glitch_2 %}data-fx-glitch{% endif %}
+                  {% if block.settings.button_decode_2 %}data-scramble{% endif %}
                 >
                   {{- block.settings.button_label_2 | escape -}}
                 </a>
@@ -463,6 +471,45 @@
           "label": "t:sections.image-banner.blocks.buttons.settings.button_style_secondary_1.label"
         },
         {
+          "type": "select",
+          "id": "neon_style_1",
+          "label": "First button — neon style",
+          "info": "Layers OmniTask neon glow on top of the standard button.",
+          "options": [
+            { "value": "", "label": "None (theme default)" },
+            { "value": "outline", "label": "Neon outline" },
+            { "value": "fill", "label": "Neon fill" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "select",
+          "id": "neon_color_1",
+          "label": "First button — neon color",
+          "options": [
+            { "value": "", "label": "Default" },
+            { "value": "cyan", "label": "Cyan" },
+            { "value": "purple", "label": "Purple" },
+            { "value": "magenta", "label": "Magenta" },
+            { "value": "pink", "label": "Pink" },
+            { "value": "green", "label": "Green" },
+            { "value": "blue", "label": "Blue" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "checkbox",
+          "id": "button_glitch_1",
+          "label": "First button — glitch on hover/click",
+          "default": false
+        },
+        {
+          "type": "checkbox",
+          "id": "button_decode_1",
+          "label": "First button — decode label on first hover",
+          "default": false
+        },
+        {
         "type": "header",
         "content": "t:sections.image-banner.blocks.buttons.settings.header_2.content"
         },
@@ -483,6 +530,45 @@
           "id": "button_style_secondary_2",
           "default": false,
           "label": "t:sections.image-banner.blocks.buttons.settings.button_style_secondary_2.label"
+        },
+        {
+          "type": "select",
+          "id": "neon_style_2",
+          "label": "Second button — neon style",
+          "info": "Layers OmniTask neon glow on top of the standard button.",
+          "options": [
+            { "value": "", "label": "None (theme default)" },
+            { "value": "outline", "label": "Neon outline" },
+            { "value": "fill", "label": "Neon fill" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "select",
+          "id": "neon_color_2",
+          "label": "Second button — neon color",
+          "options": [
+            { "value": "", "label": "Default" },
+            { "value": "cyan", "label": "Cyan" },
+            { "value": "purple", "label": "Purple" },
+            { "value": "magenta", "label": "Magenta" },
+            { "value": "pink", "label": "Pink" },
+            { "value": "green", "label": "Green" },
+            { "value": "blue", "label": "Blue" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "checkbox",
+          "id": "button_glitch_2",
+          "label": "Second button — glitch on hover/click",
+          "default": false
+        },
+        {
+          "type": "checkbox",
+          "id": "button_decode_2",
+          "label": "Second button — decode label on first hover",
+          "default": false
         }
       ]
     }

--- a/sections/neon-button-group.liquid
+++ b/sections/neon-button-group.liquid
@@ -31,21 +31,13 @@
   }
 {%- endstyle -%}
 
-{%- liquid
-  assign section_inline_style = ''
-  if section.settings.section_glitch_duration > 0
-    assign section_inline_style = section_inline_style | append: '--ofx-glitch-duration:' | append: section.settings.section_glitch_duration | append: 'ms;'
-  endif
-  if section.settings.section_decode_duration > 0
-    assign section_inline_style = section_inline_style | append: '--ofx-decode-duration:' | append: section.settings.section_decode_duration | append: 'ms;'
-  endif
--%}
 <div
   class="neon-button-group color-{{ section.settings.color_scheme }} gradient"
+  {% if section.settings.section_apply_glitch %}data-fx-glitch-section="true"{% endif %}
+  {% if section.settings.section_apply_decode %}data-scramble-section="true"{% endif %}
   {% if section.settings.section_glitch_type != blank %}data-fx-glitch-type="{{ section.settings.section_glitch_type }}"{% endif %}
   {% if section.settings.section_decode_color != blank %}data-scramble-color="{{ section.settings.section_decode_color }}"{% endif %}
   {% if section.settings.section_decode_replay != blank %}data-scramble-replay="{{ section.settings.section_decode_replay }}"{% endif %}
-  {% if section_inline_style != blank %}style="{{ section_inline_style }}"{% endif %}
 >
   <div class="page-width section-{{ section.id }}-padding">
     {%- if section.settings.heading != blank -%}
@@ -196,16 +188,29 @@
     },
     {
       "type": "header",
-      "content": "Glitch + decode defaults for this section"
+      "content": "Activate effects for this section"
     },
     {
       "type": "paragraph",
-      "content": "Set once and every neon button + decode element in this section inherits these. Per-block settings still override."
+      "content": "These switches apply the effects globally configured in Theme settings → Neon & glitch effects to every button / decode target in this section, so you don't have to flip the per-block checkbox on each one. Per-block toggles still work for surgical overrides."
+    },
+    {
+      "type": "checkbox",
+      "id": "section_apply_glitch",
+      "label": "Apply glitch to all neon buttons in this section",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "section_apply_decode",
+      "label": "Apply decode to all button labels in this section",
+      "default": false
     },
     {
       "type": "select",
       "id": "section_glitch_type",
-      "label": "Glitch type",
+      "label": "Glitch type override (optional)",
+      "info": "Leave on Inherit to use the global Glitch type from theme settings.",
       "options": [
         { "value": "", "label": "Inherit from theme settings" },
         { "value": "slice", "label": "Slice (PowerGlitch)" },
@@ -218,19 +223,9 @@
       "default": ""
     },
     {
-      "type": "range",
-      "id": "section_glitch_duration",
-      "label": "Glitch duration",
-      "min": 0,
-      "max": 2000,
-      "step": 50,
-      "unit": "ms",
-      "default": 0
-    },
-    {
       "type": "select",
       "id": "section_decode_color",
-      "label": "Decode glyph color source",
+      "label": "Decode glyph color override (optional)",
       "options": [
         { "value": "", "label": "Inherit from theme settings" },
         { "value": "rotate", "label": "Rotate (uses scheme palette)" },
@@ -245,19 +240,9 @@
       "default": ""
     },
     {
-      "type": "range",
-      "id": "section_decode_duration",
-      "label": "Decode duration",
-      "min": 0,
-      "max": 2000,
-      "step": 50,
-      "unit": "ms",
-      "default": 0
-    },
-    {
       "type": "select",
       "id": "section_decode_replay",
-      "label": "Replay decode on hover",
+      "label": "Replay decode on hover (optional)",
       "options": [
         { "value": "", "label": "Inherit from theme settings" },
         { "value": "once", "label": "Once per page load" },

--- a/sections/neon-button-group.liquid
+++ b/sections/neon-button-group.liquid
@@ -1,0 +1,286 @@
+{{ 'neon-glitch.css' | asset_url | stylesheet_tag }}
+
+{%- style -%}
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+    padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+  }
+
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: {{ section.settings.padding_top }}px;
+      padding-bottom: {{ section.settings.padding_bottom }}px;
+    }
+  }
+
+  .neon-button-group__inner {
+    display: flex;
+    flex-wrap: wrap;
+    gap: {{ section.settings.button_gap }}px;
+    justify-content: {{ section.settings.alignment }};
+    align-items: center;
+  }
+
+  .neon-button-group__heading {
+    text-align: {{ section.settings.text_alignment }};
+    margin: 0 0 2.4rem;
+  }
+{%- endstyle -%}
+
+<div class="neon-button-group color-{{ section.settings.color_scheme }} gradient">
+  <div class="page-width section-{{ section.id }}-padding">
+    {%- if section.settings.heading != blank -%}
+      <h2
+        class="neon-button-group__heading {{ section.settings.heading_size }}{% if section.settings.heading_neon %} text-neon{% endif %}{% if section.settings.heading_flicker %} text-neon-flicker{% endif %}"
+        {% if section.settings.heading_decode %}data-scramble{% endif %}
+        {% if section.settings.heading_neon_color != blank %}style="--ofx-neon-rgb: var(--ofx-{{ section.settings.heading_neon_color }}-rgb);"{% endif %}
+      >
+        {{ section.settings.heading }}
+      </h2>
+    {%- endif -%}
+
+    <div class="neon-button-group__inner">
+      {%- for block in section.blocks -%}
+        {%- case block.type -%}
+          {%- when 'neon_button' -%}
+            {% render 'neon-button',
+              label: block.settings.button_label,
+              link: block.settings.button_link,
+              color: block.settings.color,
+              style: block.settings.style,
+              base: block.settings.base,
+              glitch: block.settings.glitch,
+              decode: block.settings.decode
+            %}
+        {%- endcase -%}
+      {%- endfor -%}
+    </div>
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Neon button group",
+  "tag": "section",
+  "class": "section",
+  "disabled_on": {
+    "groups": ["header", "footer"]
+  },
+  "settings": [
+    {
+      "type": "header",
+      "content": "Heading"
+    },
+    {
+      "type": "inline_richtext",
+      "id": "heading",
+      "label": "Heading",
+      "default": "Power up"
+    },
+    {
+      "type": "select",
+      "id": "heading_size",
+      "label": "Heading size",
+      "options": [
+        { "value": "h2", "label": "H2" },
+        { "value": "h1", "label": "H1" },
+        { "value": "h0", "label": "H0" }
+      ],
+      "default": "h1"
+    },
+    {
+      "type": "checkbox",
+      "id": "heading_neon",
+      "label": "Apply neon glow to heading",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "heading_flicker",
+      "label": "Flicker the neon glow",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "heading_decode",
+      "label": "Decode/scramble heading on first hover",
+      "default": true
+    },
+    {
+      "type": "select",
+      "id": "heading_neon_color",
+      "label": "Heading neon color",
+      "options": [
+        { "value": "cyan", "label": "Cyan" },
+        { "value": "purple", "label": "Purple" },
+        { "value": "magenta", "label": "Magenta" },
+        { "value": "pink", "label": "Pink" },
+        { "value": "green", "label": "Green" },
+        { "value": "blue", "label": "Blue" }
+      ],
+      "default": "cyan"
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "select",
+      "id": "alignment",
+      "label": "Button alignment",
+      "options": [
+        { "value": "flex-start", "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "flex-end", "label": "Right" }
+      ],
+      "default": "center"
+    },
+    {
+      "type": "select",
+      "id": "text_alignment",
+      "label": "Heading alignment",
+      "options": [
+        { "value": "left", "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right", "label": "Right" }
+      ],
+      "default": "center"
+    },
+    {
+      "type": "range",
+      "id": "button_gap",
+      "label": "Gap between buttons",
+      "min": 0,
+      "max": 60,
+      "step": 4,
+      "unit": "px",
+      "default": 16
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "t:sections.all.colors.label",
+      "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "Section padding"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "Top padding",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "Bottom padding",
+      "default": 36
+    }
+  ],
+  "blocks": [
+    {
+      "type": "neon_button",
+      "name": "Neon button",
+      "limit": 6,
+      "settings": [
+        {
+          "type": "text",
+          "id": "button_label",
+          "label": "Label",
+          "default": "Shop now"
+        },
+        {
+          "type": "url",
+          "id": "button_link",
+          "label": "Link"
+        },
+        {
+          "type": "select",
+          "id": "color",
+          "label": "Neon color",
+          "options": [
+            { "value": "cyan", "label": "Cyan" },
+            { "value": "purple", "label": "Purple" },
+            { "value": "magenta", "label": "Magenta" },
+            { "value": "pink", "label": "Pink" },
+            { "value": "green", "label": "Green" },
+            { "value": "blue", "label": "Blue" }
+          ],
+          "default": "cyan"
+        },
+        {
+          "type": "select",
+          "id": "style",
+          "label": "Style",
+          "options": [
+            { "value": "outline", "label": "Outline (transparent fill)" },
+            { "value": "fill", "label": "Filled (solid neon)" }
+          ],
+          "default": "outline"
+        },
+        {
+          "type": "select",
+          "id": "base",
+          "label": "Sizing",
+          "info": "Theme buttons follow Dawn's sizing; standalone matches OmniTask's exact pill.",
+          "options": [
+            { "value": "dawn", "label": "Theme buttons (.button)" },
+            { "value": "standalone", "label": "Standalone (.ofx-neon-button)" }
+          ],
+          "default": "dawn"
+        },
+        {
+          "type": "checkbox",
+          "id": "glitch",
+          "label": "Glitch on hover/click",
+          "info": "Chromatic-aberration animation on hover and an extra burst on click.",
+          "default": true
+        },
+        {
+          "type": "checkbox",
+          "id": "decode",
+          "label": "Decode label on first hover",
+          "info": "Characters scramble through random glyphs before settling on the label.",
+          "default": false
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Neon button group",
+      "blocks": [
+        {
+          "type": "neon_button",
+          "settings": {
+            "button_label": "Shop now",
+            "color": "cyan",
+            "style": "outline",
+            "glitch": true,
+            "decode": true
+          }
+        },
+        {
+          "type": "neon_button",
+          "settings": {
+            "button_label": "Learn more",
+            "color": "purple",
+            "style": "fill",
+            "glitch": true
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/neon-button-group.liquid
+++ b/sections/neon-button-group.liquid
@@ -21,6 +21,10 @@
     align-items: center;
   }
 
+  .neon-button-group__block {
+    display: inline-flex;
+  }
+
   .neon-button-group__heading {
     text-align: {{ section.settings.text_alignment }};
     margin: 0 0 2.4rem;
@@ -43,15 +47,17 @@
       {%- for block in section.blocks -%}
         {%- case block.type -%}
           {%- when 'neon_button' -%}
-            {% render 'neon-button',
-              label: block.settings.button_label,
-              link: block.settings.button_link,
-              color: block.settings.color,
-              style: block.settings.style,
-              base: block.settings.base,
-              glitch: block.settings.glitch,
-              decode: block.settings.decode
-            %}
+            <div class="neon-button-group__block" {{ block.shopify_attributes }}>
+              {% render 'neon-button',
+                label: block.settings.button_label,
+                link: block.settings.button_link,
+                color: block.settings.color,
+                style: block.settings.style,
+                base: block.settings.base,
+                glitch: block.settings.glitch,
+                decode: block.settings.decode
+              %}
+            </div>
         {%- endcase -%}
       {%- endfor -%}
     </div>

--- a/sections/neon-button-group.liquid
+++ b/sections/neon-button-group.liquid
@@ -56,6 +56,7 @@
                 base: block.settings.base,
                 glitch: block.settings.glitch,
                 decode: block.settings.decode,
+                glitch_type: block.settings.glitch_type,
                 glitch_duration: block.settings.glitch_duration,
                 glitch_slices: block.settings.glitch_slices,
                 glitch_velocity: block.settings.glitch_velocity,
@@ -275,6 +276,21 @@
         {
           "type": "paragraph",
           "content": "Leave at zero / Inherit to use the global Glitch animation settings."
+        },
+        {
+          "type": "select",
+          "id": "glitch_type",
+          "label": "Glitch type",
+          "options": [
+            { "value": "", "label": "Inherit" },
+            { "value": "slice", "label": "Slice (PowerGlitch)" },
+            { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
+            { "value": "chromatic-box", "label": "Chromatic — box ghosts" },
+            { "value": "rgb-split", "label": "RGB split (heavier chromatic)" },
+            { "value": "shake", "label": "Shake" },
+            { "value": "flicker", "label": "Flicker" }
+          ],
+          "default": ""
         },
         {
           "type": "range",

--- a/sections/neon-button-group.liquid
+++ b/sections/neon-button-group.liquid
@@ -55,7 +55,16 @@
                 style: block.settings.style,
                 base: block.settings.base,
                 glitch: block.settings.glitch,
-                decode: block.settings.decode
+                decode: block.settings.decode,
+                glitch_duration: block.settings.glitch_duration,
+                glitch_slices: block.settings.glitch_slices,
+                glitch_velocity: block.settings.glitch_velocity,
+                glitch_shake: block.settings.glitch_shake,
+                glitch_color: block.settings.glitch_color,
+                decode_duration: block.settings.decode_duration,
+                decode_color: block.settings.decode_color,
+                decode_charset: block.settings.decode_charset,
+                decode_replay: block.settings.decode_replay
               %}
             </div>
         {%- endcase -%}
@@ -258,6 +267,128 @@
           "label": "Decode label on first hover",
           "info": "Characters scramble through random glyphs before settling on the label.",
           "default": false
+        },
+        {
+          "type": "header",
+          "content": "Glitch overrides (optional)"
+        },
+        {
+          "type": "paragraph",
+          "content": "Leave at zero / Inherit to use the global Glitch animation settings."
+        },
+        {
+          "type": "range",
+          "id": "glitch_duration",
+          "label": "Duration",
+          "min": 0,
+          "max": 2000,
+          "step": 50,
+          "unit": "ms",
+          "default": 0
+        },
+        {
+          "type": "range",
+          "id": "glitch_slices",
+          "label": "Slice count",
+          "min": 0,
+          "max": 8,
+          "step": 1,
+          "default": 0
+        },
+        {
+          "type": "range",
+          "id": "glitch_velocity",
+          "label": "Slice displacement",
+          "min": 0,
+          "max": 60,
+          "step": 2,
+          "unit": "px",
+          "default": 0
+        },
+        {
+          "type": "select",
+          "id": "glitch_shake",
+          "label": "Shake whole button",
+          "options": [
+            { "value": "", "label": "Inherit" },
+            { "value": "true", "label": "On" },
+            { "value": "false", "label": "Off" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "select",
+          "id": "glitch_color",
+          "label": "Slice color source",
+          "options": [
+            { "value": "", "label": "Inherit" },
+            { "value": "match", "label": "Match button color" },
+            { "value": "chromatic", "label": "Chromatic aberration" },
+            { "value": "cyan", "label": "Cyan" },
+            { "value": "purple", "label": "Purple" },
+            { "value": "magenta", "label": "Magenta" },
+            { "value": "pink", "label": "Pink" },
+            { "value": "green", "label": "Green" },
+            { "value": "blue", "label": "Blue" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "header",
+          "content": "Decode overrides (optional)"
+        },
+        {
+          "type": "range",
+          "id": "decode_duration",
+          "label": "Duration",
+          "min": 0,
+          "max": 2000,
+          "step": 50,
+          "unit": "ms",
+          "default": 0
+        },
+        {
+          "type": "select",
+          "id": "decode_color",
+          "label": "Glyph color source",
+          "options": [
+            { "value": "", "label": "Inherit" },
+            { "value": "rotate", "label": "Rotate (cyan/pink/purple/magenta)" },
+            { "value": "match", "label": "Match button label color" },
+            { "value": "cyan", "label": "Cyan" },
+            { "value": "purple", "label": "Purple" },
+            { "value": "magenta", "label": "Magenta" },
+            { "value": "pink", "label": "Pink" },
+            { "value": "green", "label": "Green" },
+            { "value": "blue", "label": "Blue" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "select",
+          "id": "decode_charset",
+          "label": "Glyph set",
+          "options": [
+            { "value": "", "label": "Inherit" },
+            { "value": "mixed", "label": "Mixed" },
+            { "value": "blocks", "label": "Blocks" },
+            { "value": "symbols", "label": "Symbols" },
+            { "value": "binary", "label": "Binary" },
+            { "value": "hex", "label": "Hexadecimal" },
+            { "value": "katakana", "label": "Katakana" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "select",
+          "id": "decode_replay",
+          "label": "Replay decode on hover",
+          "options": [
+            { "value": "", "label": "Inherit" },
+            { "value": "once", "label": "Once per page load" },
+            { "value": "always", "label": "Every hover" }
+          ],
+          "default": ""
         }
       ]
     }

--- a/sections/neon-button-group.liquid
+++ b/sections/neon-button-group.liquid
@@ -31,7 +31,22 @@
   }
 {%- endstyle -%}
 
-<div class="neon-button-group color-{{ section.settings.color_scheme }} gradient">
+{%- liquid
+  assign section_inline_style = ''
+  if section.settings.section_glitch_duration > 0
+    assign section_inline_style = section_inline_style | append: '--ofx-glitch-duration:' | append: section.settings.section_glitch_duration | append: 'ms;'
+  endif
+  if section.settings.section_decode_duration > 0
+    assign section_inline_style = section_inline_style | append: '--ofx-decode-duration:' | append: section.settings.section_decode_duration | append: 'ms;'
+  endif
+-%}
+<div
+  class="neon-button-group color-{{ section.settings.color_scheme }} gradient"
+  {% if section.settings.section_glitch_type != blank %}data-fx-glitch-type="{{ section.settings.section_glitch_type }}"{% endif %}
+  {% if section.settings.section_decode_color != blank %}data-scramble-color="{{ section.settings.section_decode_color }}"{% endif %}
+  {% if section.settings.section_decode_replay != blank %}data-scramble-replay="{{ section.settings.section_decode_replay }}"{% endif %}
+  {% if section_inline_style != blank %}style="{{ section_inline_style }}"{% endif %}
+>
   <div class="page-width section-{{ section.id }}-padding">
     {%- if section.settings.heading != blank -%}
       <h2
@@ -176,7 +191,79 @@
       "type": "color_scheme",
       "id": "color_scheme",
       "label": "t:sections.all.colors.label",
+      "info": "Pick scheme-omnitask-cyan / -purple / -magenta / -pink / -green for tuned glitch + decode colors out of the box.",
       "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "Glitch + decode defaults for this section"
+    },
+    {
+      "type": "paragraph",
+      "content": "Set once and every neon button + decode element in this section inherits these. Per-block settings still override."
+    },
+    {
+      "type": "select",
+      "id": "section_glitch_type",
+      "label": "Glitch type",
+      "options": [
+        { "value": "", "label": "Inherit from theme settings" },
+        { "value": "slice", "label": "Slice (PowerGlitch)" },
+        { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
+        { "value": "chromatic-box", "label": "Chromatic — box ghosts" },
+        { "value": "rgb-split", "label": "RGB split (heavier chromatic)" },
+        { "value": "shake", "label": "Shake" },
+        { "value": "flicker", "label": "Flicker" }
+      ],
+      "default": ""
+    },
+    {
+      "type": "range",
+      "id": "section_glitch_duration",
+      "label": "Glitch duration",
+      "min": 0,
+      "max": 2000,
+      "step": 50,
+      "unit": "ms",
+      "default": 0
+    },
+    {
+      "type": "select",
+      "id": "section_decode_color",
+      "label": "Decode glyph color source",
+      "options": [
+        { "value": "", "label": "Inherit from theme settings" },
+        { "value": "rotate", "label": "Rotate (uses scheme palette)" },
+        { "value": "match", "label": "Match the element's own color" },
+        { "value": "cyan", "label": "Cyan" },
+        { "value": "purple", "label": "Purple" },
+        { "value": "magenta", "label": "Magenta" },
+        { "value": "pink", "label": "Pink" },
+        { "value": "green", "label": "Green" },
+        { "value": "blue", "label": "Blue" }
+      ],
+      "default": ""
+    },
+    {
+      "type": "range",
+      "id": "section_decode_duration",
+      "label": "Decode duration",
+      "min": 0,
+      "max": 2000,
+      "step": 50,
+      "unit": "ms",
+      "default": 0
+    },
+    {
+      "type": "select",
+      "id": "section_decode_replay",
+      "label": "Replay decode on hover",
+      "options": [
+        { "value": "", "label": "Inherit from theme settings" },
+        { "value": "once", "label": "Once per page load" },
+        { "value": "always", "label": "Every hover" }
+      ],
+      "default": ""
     },
     {
       "type": "header",

--- a/sections/video-banner.liquid
+++ b/sections/video-banner.liquid
@@ -94,7 +94,17 @@
     </div>
 
     <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
-      <div class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient">
+      {%- liquid
+        assign banner_inline_style = ''
+        if section.settings.section_glitch_duration > 0
+          assign banner_inline_style = banner_inline_style | append: '--ofx-glitch-duration:' | append: section.settings.section_glitch_duration | append: 'ms;'
+        endif
+      -%}
+      <div
+        class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient"
+        {% if section.settings.section_glitch_type != blank %}data-fx-glitch-type="{{ section.settings.section_glitch_type }}"{% endif %}
+        {% if banner_inline_style != blank %}style="{{ banner_inline_style }}"{% endif %}
+      >
         {%- for block in section.blocks -%}
           {%- case block.type -%}
             {%- when 'heading' -%}
@@ -309,7 +319,38 @@
       "type": "color_scheme",
       "id": "color_scheme",
       "label": "Color scheme",
+      "info": "Pick scheme-omnitask-cyan / -purple / -magenta / -pink / -green for tuned glitch + decode colors out of the box.",
       "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "Glitch defaults for buttons in this section"
+    },
+    {
+      "type": "select",
+      "id": "section_glitch_type",
+      "label": "Glitch type",
+      "info": "Applied to any button in this section that has 'Glitch on hover/click' enabled. Per-button overrides still win.",
+      "options": [
+        { "value": "", "label": "Inherit from theme settings" },
+        { "value": "slice", "label": "Slice (PowerGlitch)" },
+        { "value": "chromatic-text", "label": "Chromatic — text ghosts" },
+        { "value": "chromatic-box", "label": "Chromatic — box ghosts" },
+        { "value": "rgb-split", "label": "RGB split (heavier chromatic)" },
+        { "value": "shake", "label": "Shake" },
+        { "value": "flicker", "label": "Flicker" }
+      ],
+      "default": ""
+    },
+    {
+      "type": "range",
+      "id": "section_glitch_duration",
+      "label": "Glitch duration",
+      "min": 0,
+      "max": 2000,
+      "step": 50,
+      "unit": "ms",
+      "default": 0
     },
     {
       "type": "header",

--- a/sections/video-banner.liquid
+++ b/sections/video-banner.liquid
@@ -94,16 +94,11 @@
     </div>
 
     <div class="banner__content banner__content--{{ section.settings.desktop_content_position }} page-width{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}">
-      {%- liquid
-        assign banner_inline_style = ''
-        if section.settings.section_glitch_duration > 0
-          assign banner_inline_style = banner_inline_style | append: '--ofx-glitch-duration:' | append: section.settings.section_glitch_duration | append: 'ms;'
-        endif
-      -%}
       <div
         class="banner__box content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient"
+        {% if section.settings.section_apply_glitch %}data-fx-glitch-section="true"{% endif %}
+        {% if section.settings.section_apply_decode %}data-scramble-section="true"{% endif %}
         {% if section.settings.section_glitch_type != blank %}data-fx-glitch-type="{{ section.settings.section_glitch_type }}"{% endif %}
-        {% if banner_inline_style != blank %}style="{{ banner_inline_style }}"{% endif %}
       >
         {%- for block in section.blocks -%}
           {%- case block.type -%}
@@ -324,13 +319,29 @@
     },
     {
       "type": "header",
-      "content": "Glitch defaults for buttons in this section"
+      "content": "Activate effects for this section"
+    },
+    {
+      "type": "paragraph",
+      "content": "Apply the global glitch / decode effects to every button in this section in one click — duration, slice count and other parameters live in Theme settings → Neon & glitch effects."
+    },
+    {
+      "type": "checkbox",
+      "id": "section_apply_glitch",
+      "label": "Apply glitch to all buttons in this section",
+      "default": false
+    },
+    {
+      "type": "checkbox",
+      "id": "section_apply_decode",
+      "label": "Apply decode to all button labels in this section",
+      "default": false
     },
     {
       "type": "select",
       "id": "section_glitch_type",
-      "label": "Glitch type",
-      "info": "Applied to any button in this section that has 'Glitch on hover/click' enabled. Per-button overrides still win.",
+      "label": "Glitch type override (optional)",
+      "info": "Leave on Inherit to use the global Glitch type from theme settings.",
       "options": [
         { "value": "", "label": "Inherit from theme settings" },
         { "value": "slice", "label": "Slice (PowerGlitch)" },
@@ -341,16 +352,6 @@
         { "value": "flicker", "label": "Flicker" }
       ],
       "default": ""
-    },
-    {
-      "type": "range",
-      "id": "section_glitch_duration",
-      "label": "Glitch duration",
-      "min": 0,
-      "max": 2000,
-      "step": 50,
-      "unit": "ms",
-      "default": 0
     },
     {
       "type": "header",

--- a/sections/video-banner.liquid
+++ b/sections/video-banner.liquid
@@ -113,6 +113,10 @@
                 class="banner__buttons{% if block.settings.button_label_1 != blank and block.settings.button_label_2 != blank %} banner__buttons--multiple{% endif %}"
                 {{ block.shopify_attributes }}
               >
+                {%- liquid
+                  assign neon_color_1 = block.settings.neon_color_1 | default: ''
+                  assign neon_color_2 = block.settings.neon_color_2 | default: ''
+                -%}
                 {%- if block.settings.button_label_1 != blank -%}
                   <a
                     {% if block.settings.button_link_1 == blank %}
@@ -120,7 +124,9 @@
                     {% else %}
                       href="{{ block.settings.button_link_1 }}"
                     {% endif %}
-                    class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"
+                    class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}{% if block.settings.neon_style_1 == 'outline' %} button--neon{% elsif block.settings.neon_style_1 == 'fill' %} button--neon-fill{% endif %}{% if neon_color_1 != blank %} button--neon--{{ neon_color_1 }}{% endif %}"
+                    {% if block.settings.button_glitch_1 %}data-fx-glitch{% endif %}
+                    {% if block.settings.button_decode_1 %}data-scramble{% endif %}
                   >
                     {{- block.settings.button_label_1 | escape -}}
                   </a>
@@ -132,7 +138,9 @@
                     {% else %}
                       href="{{ block.settings.button_link_2 }}"
                     {% endif %}
-                    class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"
+                    class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}{% if block.settings.neon_style_2 == 'outline' %} button--neon{% elsif block.settings.neon_style_2 == 'fill' %} button--neon-fill{% endif %}{% if neon_color_2 != blank %} button--neon--{{ neon_color_2 }}{% endif %}"
+                    {% if block.settings.button_glitch_2 %}data-fx-glitch{% endif %}
+                    {% if block.settings.button_decode_2 %}data-scramble{% endif %}
                   >
                     {{- block.settings.button_label_2 | escape -}}
                   </a>
@@ -411,6 +419,46 @@
           "label": "Use outline button style"
         },
         {
+          "type": "select",
+          "id": "neon_style_1",
+          "label": "First button — neon style",
+          "info": "Layers OmniTask neon glow on top of the standard button.",
+          "options": [
+            { "value": "", "label": "None (theme default)" },
+            { "value": "outline", "label": "Neon outline" },
+            { "value": "fill", "label": "Neon fill" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "select",
+          "id": "neon_color_1",
+          "label": "First button — neon color",
+          "info": "Leave on Default to inherit from the section's color scheme.",
+          "options": [
+            { "value": "", "label": "Default (scheme)" },
+            { "value": "cyan", "label": "Cyan" },
+            { "value": "purple", "label": "Purple" },
+            { "value": "magenta", "label": "Magenta" },
+            { "value": "pink", "label": "Pink" },
+            { "value": "green", "label": "Green" },
+            { "value": "blue", "label": "Blue" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "checkbox",
+          "id": "button_glitch_1",
+          "label": "First button — glitch on hover/click",
+          "default": false
+        },
+        {
+          "type": "checkbox",
+          "id": "button_decode_1",
+          "label": "First button — decode label on first hover",
+          "default": false
+        },
+        {
           "type": "header",
           "content": "Button 2"
         },
@@ -431,6 +479,46 @@
           "id": "button_style_secondary_2",
           "default": false,
           "label": "Use outline button style"
+        },
+        {
+          "type": "select",
+          "id": "neon_style_2",
+          "label": "Second button — neon style",
+          "info": "Layers OmniTask neon glow on top of the standard button.",
+          "options": [
+            { "value": "", "label": "None (theme default)" },
+            { "value": "outline", "label": "Neon outline" },
+            { "value": "fill", "label": "Neon fill" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "select",
+          "id": "neon_color_2",
+          "label": "Second button — neon color",
+          "info": "Leave on Default to inherit from the section's color scheme.",
+          "options": [
+            { "value": "", "label": "Default (scheme)" },
+            { "value": "cyan", "label": "Cyan" },
+            { "value": "purple", "label": "Purple" },
+            { "value": "magenta", "label": "Magenta" },
+            { "value": "pink", "label": "Pink" },
+            { "value": "green", "label": "Green" },
+            { "value": "blue", "label": "Blue" }
+          ],
+          "default": ""
+        },
+        {
+          "type": "checkbox",
+          "id": "button_glitch_2",
+          "label": "Second button — glitch on hover/click",
+          "default": false
+        },
+        {
+          "type": "checkbox",
+          "id": "button_decode_2",
+          "label": "Second button — decode label on first hover",
+          "default": false
         }
       ]
     }

--- a/snippets/neon-button.liquid
+++ b/snippets/neon-button.liquid
@@ -15,10 +15,27 @@
     decode  {boolean} - apply text decode/scramble on first hover
     classes {string}  - extra classes to append
 
+    Glitch overrides (only meaningful with glitch: true):
+      glitch_duration {number} - ms; falls back to global setting
+      glitch_slices   {number} - 1-8 slice count override
+      glitch_velocity {number} - max horizontal slice offset (px)
+      glitch_shake    {string} - 'true' | 'false'
+      glitch_color    {string} - match | chromatic | cyan | purple |
+                                 magenta | pink | green | blue
+
+    Decode overrides (only meaningful with decode: true):
+      decode_duration {number} - ms; falls back to global setting
+      decode_color    {string} - rotate | match | cyan | purple |
+                                 magenta | pink | green | blue
+      decode_charset  {string} - mixed | blocks | symbols | binary |
+                                 hex | katakana
+      decode_replay   {string} - 'once' | 'always'
+
   Usage:
     {% render 'neon-button',
         label: 'Shop now', link: '/collections/all',
-        color: 'purple', style: 'outline', glitch: true %}
+        color: 'purple', style: 'outline',
+        glitch: true, glitch_duration: 600, glitch_color: 'chromatic' %}
 {% endcomment %}
 
 {%- liquid
@@ -56,8 +73,21 @@
   <a
     {% if btn_link == blank %}role="link" aria-disabled="true"{% else %}href="{{ btn_link }}"{% endif %}
     class="{{ class_list }}"
-    {% if glitch %}data-fx-glitch{% endif %}
-    {% if decode %}data-scramble{% endif %}
+    {% if glitch %}
+      data-fx-glitch
+      {% if glitch_duration %}data-fx-glitch-duration="{{ glitch_duration }}"{% endif %}
+      {% if glitch_slices %}data-fx-glitch-slices="{{ glitch_slices }}"{% endif %}
+      {% if glitch_velocity %}data-fx-glitch-velocity="{{ glitch_velocity }}"{% endif %}
+      {% if glitch_shake %}data-fx-glitch-shake="{{ glitch_shake }}"{% endif %}
+      {% if glitch_color != blank %}data-fx-glitch-color="{{ glitch_color }}"{% endif %}
+    {% endif %}
+    {% if decode %}
+      data-scramble
+      {% if decode_duration %}data-scramble-duration="{{ decode_duration }}"{% endif %}
+      {% if decode_color != blank %}data-scramble-color="{{ decode_color }}"{% endif %}
+      {% if decode_charset != blank %}data-scramble-charset="{{ decode_charset }}"{% endif %}
+      {% if decode_replay != blank %}data-scramble-replay="{{ decode_replay }}"{% endif %}
+    {% endif %}
   >
     {{- btn_label | escape -}}
   </a>

--- a/snippets/neon-button.liquid
+++ b/snippets/neon-button.liquid
@@ -1,0 +1,64 @@
+{% comment %}
+  Renders an OmniTask-flavored neon button.
+
+  Accepts:
+    label   {string}  - button text (required)
+    link    {string}  - href; if blank, renders as aria-disabled
+    color   {string}  - cyan | purple | magenta | pink | green | blue (default cyan)
+    style   {string}  - 'outline' | 'fill' (default 'outline')
+    base    {string}  - 'dawn' | 'standalone' (default 'dawn')
+                        'dawn' layers neon classes on Dawn's .button so
+                        sizing matches the rest of the theme; 'standalone'
+                        uses .ofx-neon-button which more closely mimics
+                        OmniTask's exact pill shape.
+    glitch  {boolean} - apply chromatic-aberration glitch on hover/active
+    decode  {boolean} - apply text decode/scramble on first hover
+    classes {string}  - extra classes to append
+
+  Usage:
+    {% render 'neon-button',
+        label: 'Shop now', link: '/collections/all',
+        color: 'purple', style: 'outline', glitch: true %}
+{% endcomment %}
+
+{%- liquid
+  assign btn_label = label | default: ''
+  assign btn_link = link | default: ''
+  assign btn_color = color | default: 'cyan'
+  assign btn_style = style | default: 'outline'
+  assign btn_base = base | default: 'dawn'
+  assign extra_classes = classes | default: ''
+
+  assign class_list = ''
+  if btn_base == 'standalone'
+    if btn_style == 'fill'
+      assign class_list = 'ofx-neon-button-fill'
+    else
+      assign class_list = 'ofx-neon-button'
+    endif
+    assign class_list = class_list | append: ' ofx-neon--' | append: btn_color
+  else
+    assign class_list = 'button'
+    if btn_style == 'fill'
+      assign class_list = class_list | append: ' button--neon-fill'
+    else
+      assign class_list = class_list | append: ' button--neon'
+    endif
+    assign class_list = class_list | append: ' button--neon--' | append: btn_color
+  endif
+
+  if extra_classes != blank
+    assign class_list = class_list | append: ' ' | append: extra_classes
+  endif
+-%}
+
+{%- if btn_label != blank -%}
+  <a
+    {% if btn_link == blank %}role="link" aria-disabled="true"{% else %}href="{{ btn_link }}"{% endif %}
+    class="{{ class_list }}"
+    {% if glitch %}data-fx-glitch{% endif %}
+    {% if decode %}data-scramble{% endif %}
+  >
+    {{- btn_label | escape -}}
+  </a>
+{%- endif -%}

--- a/snippets/neon-button.liquid
+++ b/snippets/neon-button.liquid
@@ -16,10 +16,12 @@
     classes {string}  - extra classes to append
 
     Glitch overrides (only meaningful with glitch: true):
+      glitch_type     {string} - slice | chromatic-text | chromatic-box |
+                                 rgb-split | shake | flicker
       glitch_duration {number} - ms; falls back to global setting
-      glitch_slices   {number} - 1-8 slice count override
-      glitch_velocity {number} - max horizontal slice offset (px)
-      glitch_shake    {string} - 'true' | 'false'
+      glitch_slices   {number} - 1-8 slice count override (slice type only)
+      glitch_velocity {number} - max horizontal slice offset (px) (slice only)
+      glitch_shake    {string} - 'true' | 'false' (slice type only)
       glitch_color    {string} - match | chromatic | cyan | purple |
                                  magenta | pink | green | blue
 
@@ -75,6 +77,7 @@
     class="{{ class_list }}"
     {% if glitch %}
       data-fx-glitch
+      {% if glitch_type != blank %}data-fx-glitch-type="{{ glitch_type }}"{% endif %}
       {% if glitch_duration %}data-fx-glitch-duration="{{ glitch_duration }}"{% endif %}
       {% if glitch_slices %}data-fx-glitch-slices="{{ glitch_slices }}"{% endif %}
       {% if glitch_velocity %}data-fx-glitch-velocity="{{ glitch_velocity }}"{% endif %}


### PR DESCRIPTION
## Summary

Ports OmniTask's neon and glitch aesthetic into the OmniFlex Shopify theme so merchants can opt into glowing buttons and chromatic-aberration glitch animations without writing custom CSS.

### What's added

**`assets/neon-glitch.css`** — drop-in stylesheet with:
- Neon palette CSS variables (`--ofx-cyan`, `--ofx-purple`, `--ofx-magenta`, `--ofx-pink`, `--ofx-green`, `--ofx-blue`)
- Outline + fill button variants on top of Dawn's `.button` (`.button--neon`, `.button--neon-fill`, with color modifiers `.button--neon--{cyan,purple,magenta,pink,green,blue}`)
- Standalone OmniTask-style buttons (`.ofx-neon-button`, `.ofx-neon-button-fill`, `.ofx-neon--{color}`)
- Scramble overlay rules for `[data-scramble]` decode targets
- Chromatic-aberration glitch keyframes for `[data-fx-glitch]`, `[data-fx-glitch-hover]`, `[data-fx-glitch-click]`, `[data-fx-glitch-box]`
- Pulsing glow + flickering text utilities (`.cyber-pulse`, `.cyber-border-glow`, `.text-neon`, `.text-neon-flicker`)
- Full `prefers-reduced-motion: reduce` opt-out

**`assets/neon-glitch.js`** — vanilla port of OmniTask's `TextScrambler` plus a MutationObserver-driven auto-binder that wires `[data-scramble]` elements for one-shot decode-on-first-hover. No external dependencies; respects reduced-motion.

**`snippets/neon-button.liquid`** — reusable snippet accepting `label`, `link`, `color`, `style` (`outline` / `fill`), `base` (`dawn` / `standalone`), `glitch`, `decode`, and `classes` parameters.

**`sections/neon-button-group.liquid`** — drag-and-drop section with up to 6 neon button blocks. Each block exposes color, fill/outline, sizing, glitch, and decode toggles. Section also offers a neon heading with optional flicker and decode.

**`layout/theme.liquid`** — loads the new CSS/JS, injects merchant palette overrides as inline CSS variables, and (when enabled in theme settings) neon-styles every theme button with a global glitch hover.

**`config/settings_schema.json`** — adds a "Neon & glitch effects" panel with global toggles, default neon color, and per-color overrides (cyan, purple, magenta, pink, green, blue).

### How to use

Merchants can:
1. Drop the new **Neon button group** section into any page and configure heading + 1–6 buttons via theme editor
2. Render any neon button inline from a custom-liquid block: `{% render 'neon-button', label: 'Shop', link: '/collections/all', color: 'purple', style: 'fill', glitch: true, decode: true %}`
3. Enable **Apply neon glow to all theme buttons** + **Glitch animation on every button hover/click** in Theme settings → Neon & glitch effects to apply the look storefront-wide
4. Add `data-scramble` to any heading to get the decode animation, and `data-fx-glitch` (text) or `data-fx-glitch-box` (cards/icon buttons) to get the chromatic-aberration glitch on hover

## Test plan

- [ ] Verify the theme loads without console errors on the storefront and in the Theme Editor
- [ ] Add the "Neon button group" section, confirm it renders in editor and on the storefront with default colors
- [ ] Toggle each color/style/glitch/decode option per block, verify visual change in preview
- [ ] Enable "Apply neon glow to all theme buttons" and confirm primary/secondary buttons across cart, product, and homepage pick up the neon look
- [ ] Enable "Glitch animation on every button hover/click" and confirm the chromatic-aberration animation fires on hover and the burst on click
- [ ] Set OS-level Reduce Motion and confirm all glitch + scramble + flicker animations are skipped
- [ ] Override one of the palette colors in Theme settings and verify the matching color modifier picks up the new value
- [ ] Hover a `[data-scramble]` heading and confirm the decode animation plays once, after which the static text remains


---
_Generated by [Claude Code](https://claude.ai/code/session_01XfUvNELzBnfw9gmr4ddkMz)_