### PR TITLE
Investigation: Webflow frontend + Shopify backend feasibility

### DIFF
--- a/docs/webflow-integration-investigation.md
+++ b/docs/webflow-integration-investigation.md
@@ -1,0 +1,148 @@
+# Webflow Frontend + Shopify Backend — Feasibility Investigation
+
+Investigation of rebuilding the OmniFlex storefront on Webflow while keeping commerce on Shopify. Written against the current theme on `claude/webflow-integration-investigation-Hr7vb`.
+
+## TL;DR
+
+A Webflow rebuild is **technically feasible but architecturally lossy**. The current theme is a heavily customized Shopify Dawn 12 build (~21K lines of Liquid, ~28K lines of JS/CSS, 60+ sections, custom 3D/video work, metaobject‑driven supplement pages, localization across 28 locales, customer account flows). Webflow is a strong page builder and CMS, but it is **not a headless Shopify rendering engine** — there is no first‑class Storefront API binding, no Liquid runtime, and no native equivalent for metaobjects, variant pickers, multi‑currency, customer accounts, or Shopify checkout extensibility.
+
+**Recommended path** if the goal is "Webflow look & feel without losing Shopify": **Hybrid (Option B)** — Webflow for marketing/content pages on `www`, Shopify for `/products`, `/cart`, `/account`, `/checkout`. It is the only option that does not strand existing Shopify data and customer flows.
+
+A full headless rebuild on Webflow (Option C) is possible but requires a third‑party sync layer, custom JS for cart/PDP, and is the most expensive path for the least functional gain. A pure headless rebuild without Webflow (Hydrogen/Next.js + Shopify Storefront API) is the standard industry pattern and worth weighing against any Webflow plan.
+
+---
+
+## 1. What we actually have today
+
+| Surface | Implementation | Shopify dependency |
+|---|---|---|
+| Homepage | `templates/index.json` driving sections (video banner, video slideshow, scroll‑3D, etc.) | Low — content only |
+| Marketing pages | `page.3d-landing`, `page.about-us`, `page.canvas-page`, `page.contact`, `page.default-omniflex-page` | Low — content only |
+| Product listing | `main-collection-product-grid` + `facets` snippet | Medium — collection data, filters |
+| Product detail | `main-product` + variant picker, swatches, sizing chart, buy buttons, related products, metafield‑driven labels | **High** — variants, inventory, metafields, line item properties |
+| Supplement pages | `metaobject/supplement_page.*` templates | **High** — Shopify metaobjects |
+| Cart | `cart-drawer`, `main-cart-items`, `main-cart-footer`, AJAX cart JS | **High** — Cart API |
+| Checkout | Shopify-hosted | **Hard dependency** |
+| Customer accounts | `templates/customers/*` (account, login, register, addresses, order, reset, activate) | **Hard dependency** — Shopify Customer Accounts |
+| Search | `main-search`, `predictive-search` | Medium — Search & Discovery API |
+| Localization | `locales/*` (28 base + schema files) | High — Shopify Markets |
+| 3D / scroll‑video / neon cursor | Custom JS + Liquid | Low — bundle as Webflow embeds |
+
+**Lines of code in scope for a rewrite** (rough): ~21K Liquid + ~28K CSS/JS + ~60 sections + ~36 snippets. Anything that consumes `product.metafields`, `cart`, `customer`, `shop.locale`, `recommendations`, or metaobjects is a non‑trivial port.
+
+---
+
+## 2. The four real architecture options
+
+### Option A — Webflow for everything, Shopify Buy Button SDK for cart
+Webflow renders all pages. Add‑to‑cart is the [Shopify Buy Button JS SDK](https://shopify.dev/docs/api/storefront/latest) injected as a custom `<script>`. Checkout pops out to Shopify's hosted checkout.
+
+- ✅ Cheapest Shopify plan possible (Lite / Starter, ~$5–9/mo) since you don't need a theme
+- ✅ All Webflow Interactions, CMS, Designer benefits
+- ❌ **You lose customer accounts UI** — the Buy Button SDK does not render order history, addresses, or login. Customers would need to be redirected to Shopify's account pages on a different domain.
+- ❌ **You lose Shop Pay one‑click, dynamic checkout buttons, Apple/Google Pay smart buttons** unless you also load Shopify's full storefront on at least the cart route.
+- ❌ Cart drawer must be rewritten in vanilla JS against the Storefront API (Buy Button's drawer is not very themable)
+- ❌ Variant pickers, swatches, related products, sizing chart, line item properties — all rebuilt by hand
+- ❌ Metaobjects: no SDK support — must be fetched via Storefront API (custom JS) or duplicated in Webflow CMS
+- ❌ Localization: Shopify Markets only applies at checkout. Webflow has localization (paid add‑on, ~$9–$29/mo per locale) but it does not sync to Shopify. Multi‑currency requires reading `Shop.paymentSettings.enabledPresentmentCurrencies` via Storefront API.
+- ❌ SEO: collection/product pages are client-rendered → poor crawl unless you statically pre‑generate from Webflow CMS
+
+### Option B — Hybrid: Webflow on `www`, Shopify on `shop` (RECOMMENDED)
+Webflow handles the homepage, About, founder, 3D landing, blog/editorial — anything that's "marketing." Shopify keeps `/products/*`, `/collections/*`, `/cart`, `/checkout`, `/account/*` on a separate subdomain or path.
+
+- ✅ Zero Shopify regression — variants, metaobjects, metafields, customer accounts, Markets, subscriptions, Shop Pay all keep working
+- ✅ Content team gets Webflow Designer + Editor for marketing iteration speed
+- ✅ Product/marketing teams can decouple deploy cycles
+- ✅ SEO friendly on both halves
+- ⚠️ Two CDNs, two analytics setups, two cookie domains → cross‑domain identity stitching for GA4/Shopify Customer Events
+- ⚠️ Shared header/footer must be either duplicated or served via embed (Webflow → Shopify via iframe/script is brittle; the typical pattern is to rebuild the same header in both)
+- ⚠️ Auth nav: "logged in as…" widget on `www` would need a small JS shim that calls Shopify Customer Account API
+- 💲 Webflow CMS or Business plan ($29–$49/mo) + existing Shopify plan
+
+This is the path most premium DTC brands run when they want Webflow's design polish (e.g., several brands use Shopify behind a Webflow marketing site).
+
+### Option C — Webflow as headless frontend, Shopify as commerce API
+Use a sync tool ([Udesly](https://udesly.com/), [Foxy.io](https://foxy.io/), [Webify](https://webify.app/), [Shoplift/Shoppy](https://shoplift.app/), or a custom worker) to mirror Shopify products into Webflow CMS Collections. Cart is custom JS over the Storefront API. Checkout still hands off to Shopify.
+
+- ✅ Single Webflow domain, Webflow Designer everywhere
+- ✅ CMS-templated PDP/PLP with Webflow's design system
+- ❌ **All commerce UI is custom JS you maintain forever** — variant selection, inventory, swatches, related products, predictive search, facets, cart drawer
+- ❌ Sync lag: product/inventory updates are not real-time. Out‑of‑stock states will drift unless you also call the Storefront API at runtime.
+- ❌ Webflow CMS limits: 10,000 items on Business, 20 reference fields per collection, 30 fields per item. Variant explosions (color × size × etc.) hit these ceilings fast.
+- ❌ Metaobjects: must be flattened into separate Webflow CMS collections per metaobject definition, with manual schema mapping
+- ❌ Customer accounts: same problem as Option A — redirect to Shopify
+- ❌ Localization: as Option A
+- ❌ Shopify app ecosystem (reviews, upsell, subscriptions, bundles) mostly stops working — apps inject into Liquid/theme app extensions
+- 💲 Webflow Business + sync tool (typically $20–$200/mo) + Shopify
+
+### Option D — Drop Webflow, go fully headless
+For completeness: Hydrogen (React, Shopify-native, Oxygen hosting included free with Shopify) or Next.js + Storefront API. This is what most of the "Shopify but custom frontend" market actually does. Trades visual editing for engineering velocity and 100% feature parity. Worth comparing dollar‑for‑dollar against Option C — Hydrogen is free, Webflow + sync tool is not.
+
+---
+
+## 3. Where Webflow specifically falls short for this site
+
+| Feature in current theme | Webflow native? | Workaround |
+|---|---|---|
+| Variant pickers / swatches | No | Custom JS on Storefront API; or use Shopify-rendered iframe |
+| Metaobject‑driven supplement pages | No | Mirror to Webflow CMS via sync, or fetch via Storefront API at runtime |
+| Customer accounts (login/orders/addresses) | No | Redirect to Shopify subdomain |
+| Multi-currency / Shopify Markets | No | Webflow Localization (separate $) — does not auto‑sync rates |
+| 28 locales translation files | Partial | Webflow Localization is per-page, not key‑value; content must be rebuilt per locale |
+| Cart drawer w/ line item properties, gift recipient, discounts | No | Custom JS |
+| Predictive search + facets | No | Custom (Algolia / Searchanise / Shopify Search & Discovery via Storefront API) |
+| Subscriptions / selling plans | No | Only renderable via Shopify checkout — must keep Shopify on PDP or use app's hosted widget |
+| Shop Pay / Dynamic checkout buttons | No | Buy Button SDK approximates; loses Shop Pay autofill on non-Shopify domain |
+| Metafields rendered in PDP (clothing‑features, sizing) | No | Sync layer or runtime fetch |
+| Theme editor / merchandiser drag‑drop | Partial | Webflow Editor exists but is content‑only, not Shopify‑section equivalent |
+| Custom 3D / scroll‑video / neon cursor JS | Yes (custom embed) | Port as Webflow custom code components |
+| App ecosystem (reviews, upsell, etc.) | No | Most break; need apps with embeddable JS widgets |
+
+---
+
+## 4. Effort estimate (rough, for Option B Hybrid)
+
+| Workstream | Effort |
+|---|---|
+| Webflow design system (typography, colors, components) | 2–3 weeks |
+| Marketing page rebuild (home, about, founder, 3D landing, canvas, contact) | 3–5 weeks |
+| Custom interactions port (3D showcase, neon cursor, scroll video, gradient marquee) | 2–3 weeks |
+| Shared header/footer parity across Webflow + Shopify | 1–2 weeks |
+| Cross‑domain analytics, consent, and auth state | 1 week |
+| Shopify theme cleanup (strip marketing‑only sections) | 1 week |
+| QA, SEO redirects, launch | 1–2 weeks |
+| **Total** | **~11–17 weeks** with one designer + one engineer |
+
+Option C adds ~6–10 weeks for the commerce sync layer and custom PDP/PLP/cart.
+Option A is ~Option C + customer account redirect work, but with a flat Webflow learning curve.
+
+---
+
+## 5. Risks and gotchas specific to this codebase
+
+1. **Metaobjects are not portable.** `templates/metaobject/supplement_page.*` is a Shopify-only construct. Any non-hybrid option requires either keeping `/metaobjects/*` URLs on Shopify or rebuilding them as Webflow CMS collections (one per metaobject type), losing the merchandiser UX in the Shopify admin.
+2. **Localization scope is large.** 28 base locales plus schema files. Webflow Localization charges per locale and bills annually; 28 locales is likely cost-prohibitive (~$250+/mo at list pricing) and would require re-translating content in Webflow.
+3. **Customer account templates are non-trivial.** `customers/order.json` renders historical orders, refunds, fulfillment status — none of which is exposable outside Shopify without the Customer Account API and a custom React/JS app. Hybrid (Option B) avoids this by leaving `/account/*` on Shopify.
+4. **Theme app extensions break.** Any Shopify app injecting blocks via app embeds (reviews, upsells, A/B testing, klaviyo forms, etc.) needs to be re-evaluated. Many vendors offer Webflow embeds, but not all.
+5. **Discount UX.** Automatic discounts and Shopify Functions only render at checkout — they will work. But cart-page badges showing "you saved $X" are theme-rendered today and won't appear in a Webflow cart UI without custom code.
+6. **SEO migration.** Existing collection/product URLs are `myshopify`-style. Any URL changes require 301 maps. Hybrid keeps them stable; Option C requires a full redirect plan.
+7. **Performance.** Shopify CDN + Liquid SSR is fast. Webflow + client‑side cart calls add round trips and tank Lighthouse on PDP. Plan for skeleton states.
+
+---
+
+## 6. Recommendation
+
+1. **If the goal is faster marketing iteration and design polish:** Option B (Hybrid). Lowest risk, highest preservation of existing investment, production‑proven pattern.
+2. **If the goal is "everything in Webflow":** Option C is the only way, but evaluate Hydrogen (Option D) first — it's free, Shopify‑native, and most teams that try Webflow‑as‑headless eventually migrate to a real headless framework.
+3. **Avoid Option A** unless OmniFlex is willing to accept downgraded checkout + no in-site customer accounts.
+
+Suggested next step: scope a 2‑week spike on Option B with one Webflow page (e.g., the About/Founder page) and a shared header rebuild, to validate cross‑domain analytics, design fidelity, and content workflow before committing to a full migration.
+
+---
+
+## Appendix — Source material consulted
+
+- Repo: `sections/`, `snippets/`, `templates/`, `assets/`, `locales/`, `config/`, `layout/`
+- Theme base: Shopify Dawn 12.0.0 (`Dawn-12.0.0.zip` in repo root)
+- Custom templates: `templates/page.*.json`, `templates/product.*.json`, `templates/metaobject/supplement_page.*.json`
+- Shopify dependencies surfaced via grep for `metaobject`, `metafield`, `customer`, `cart`, `selling_plan`

--- a/docs/webflow-integration-investigation.md
+++ b/docs/webflow-integration-investigation.md
@@ -1,6 +1,6 @@
 # Webflow Frontend + Shopify Backend — Feasibility Investigation
 
-Investigation of rebuilding the OmniFlex storefront on Webflow while keeping commerce on Shopify. Written against the current theme on `claude/webflow-integration-investigation-Hr7vb`.
+Investigation of rebuilding the OmniFlex storefront on Webflow while keeping commerce on Shopify. Written against the current theme version (Dawn 12.0.0).
 
 ## TL;DR
 
@@ -54,12 +54,23 @@ Webflow handles the homepage, About, founder, 3D landing, blog/editorial — any
 - ✅ Content team gets Webflow Designer + Editor for marketing iteration speed
 - ✅ Product/marketing teams can decouple deploy cycles
 - ✅ SEO friendly on both halves
-- ⚠️ Two CDNs, two analytics setups, two cookie domains → cross‑domain identity stitching for GA4/Shopify Customer Events
-- ⚠️ Shared header/footer must be either duplicated or served via embed (Webflow → Shopify via iframe/script is brittle; the typical pattern is to rebuild the same header in both)
+- ⚠️ Two CDNs, two analytics setups, two cookie domains → cross‑domain identity stitching for GA4/Shopify Customer Events. **Mitigated by sub‑option B1 below**, which collapses everything onto a single first‑party cookie domain via an edge proxy and is the recommended way to preserve attribution and SEO equity.
+- ⚠️ Shared header/footer must either be duplicated across both platforms or stitched together at the edge (see below) — pure embed via iframe/script is brittle and not recommended
 - ⚠️ Auth nav: "logged in as…" widget on `www` would need a small JS shim that calls Shopify Customer Account API
 - 💲 Webflow CMS or Business plan ($29–$49/mo) + existing Shopify plan
 
-This is the path most premium DTC brands run when they want Webflow's design polish (e.g., several brands use Shopify behind a Webflow marketing site).
+#### Sub-option B1 — Reverse proxy / edge stitching (preferred for shared chrome)
+A reverse proxy at the edge (Cloudflare Workers, Fly.io, Vercel rewrites, AWS Lambda@Edge) routes paths to either Webflow or Shopify origins under a single apex domain. Marketing routes (`/`, `/about`, `/founder`, `/blog/*`) proxy to Webflow; commerce routes (`/products/*`, `/collections/*`, `/cart`, `/checkout`, `/account/*`) proxy to Shopify. The Worker can also inject a single source-of-truth header/footer fragment into both responses (HTMLRewriter on Cloudflare, similar APIs elsewhere), eliminating the duplicate-chrome maintenance burden.
+
+- ✅ Single apex domain → no cross‑cookie/auth gymnastics, GA4/Shop Pay/Customer Events behave normally
+- ✅ One header/footer source of truth (hosted as a Webflow CMS item or a Worker-served fragment), injected into Shopify pages at the edge
+- ✅ SEO‑clean: no client‑side redirects, search engines see a single coherent site
+- ⚠️ Adds an edge service to operate (~$5–$25/mo on Cloudflare Workers for typical traffic) and a deploy step for Worker logic
+- ⚠️ Shopify checkout cannot be proxied — `/checkout` must redirect to `*.myshopify.com` (or the configured checkout domain) for PCI/Shop Pay reasons
+
+This is the more robust variant of Option B and the pattern used by most marketing-led DTC brands who want Webflow's design without splitting cookie domains. **Recommend defaulting to B1** unless ops capacity for an edge worker is a concern, in which case fall back to subdomain split with a duplicated header.
+
+This path is what most premium DTC brands run when they want Webflow's design polish behind a Shopify backend.
 
 ### Option C — Webflow as headless frontend, Shopify as commerce API
 Use a sync tool ([Udesly](https://udesly.com/), [Foxy.io](https://foxy.io/), [Webify](https://webify.app/), [Shoplift/Shoppy](https://shoplift.app/), or a custom worker) to mirror Shopify products into Webflow CMS Collections. Cart is custom JS over the Storefront API. Checkout still hands off to Shopify.
@@ -68,7 +79,7 @@ Use a sync tool ([Udesly](https://udesly.com/), [Foxy.io](https://foxy.io/), [We
 - ✅ CMS-templated PDP/PLP with Webflow's design system
 - ❌ **All commerce UI is custom JS you maintain forever** — variant selection, inventory, swatches, related products, predictive search, facets, cart drawer
 - ❌ Sync lag: product/inventory updates are not real-time. Out‑of‑stock states will drift unless you also call the Storefront API at runtime.
-- ❌ Webflow CMS limits: 10,000 items on Business, 20 reference fields per collection, 30 fields per item. Variant explosions (color × size × etc.) hit these ceilings fast.
+- ❌ Webflow CMS limits: 10,000 items on Business, 20 reference fields per collection, 30 fields per item. Variant explosions (color × size × etc.) hit these ceilings fast. **Combined with localization, this becomes a hard blocker:** if the sync mirrors one CMS item per product per locale, 28 locales × ~360 products exhausts the 10K cap. Even the Enterprise tier (typically 30K items) only buys headroom for ~1K SKUs at this locale count. For a global multi-region catalog, **Option C is effectively non‑viable on Webflow's CMS today.**
 - ❌ Metaobjects: must be flattened into separate Webflow CMS collections per metaobject definition, with manual schema mapping
 - ❌ Customer accounts: same problem as Option A — redirect to Shopify
 - ❌ Localization: as Option A
@@ -113,6 +124,8 @@ For completeness: Hydrogen (React, Shopify-native, Oxygen hosting included free 
 | QA, SEO redirects, launch | 1–2 weeks |
 | **Total** | **~11–17 weeks** with one designer + one engineer |
 
+**This is a best‑case estimate** that assumes the 28‑locale rebuild is *not* part of the initial scope (i.e., launch in English, layer locales in later, or keep localization on Shopify). Webflow Localization is per‑page rather than key‑value, so re‑translating and QA'ing 60+ section equivalents across all 28 locales is itself a multi‑month workstream that would roughly double the timeline if pulled into v1. Recommend treating localization as a separate, post‑launch phase — or as another reason to keep the localized commerce surfaces on Shopify (Option B / B1).
+
 Option C adds ~6–10 weeks for the commerce sync layer and custom PDP/PLP/cart.
 Option A is ~Option C + customer account redirect work, but with a flat Webflow learning curve.
 
@@ -125,7 +138,7 @@ Option A is ~Option C + customer account redirect work, but with a flat Webflow 
 3. **Customer account templates are non-trivial.** `customers/order.json` renders historical orders, refunds, fulfillment status — none of which is exposable outside Shopify without the Customer Account API and a custom React/JS app. Hybrid (Option B) avoids this by leaving `/account/*` on Shopify.
 4. **Theme app extensions break.** Any Shopify app injecting blocks via app embeds (reviews, upsells, A/B testing, klaviyo forms, etc.) needs to be re-evaluated. Many vendors offer Webflow embeds, but not all.
 5. **Discount UX.** Automatic discounts and Shopify Functions only render at checkout — they will work. But cart-page badges showing "you saved $X" are theme-rendered today and won't appear in a Webflow cart UI without custom code.
-6. **SEO migration.** Existing collection/product URLs are `myshopify`-style. Any URL changes require 301 maps. Hybrid keeps them stable; Option C requires a full redirect plan.
+6. **SEO migration.** Existing collection/product URLs use Shopify's standard path structure (`/products/<handle>`, `/collections/<handle>`). Hybrid (B/B1) keeps these stable; Option C requires a full 301 redirect plan. Even under Hybrid, any restructuring of marketing pages on the apex domain (homepage, about, blog) still needs its own 301 map — don't assume "Hybrid = no redirects."
 7. **Performance.** Shopify CDN + Liquid SSR is fast. Webflow + client‑side cart calls add round trips and tank Lighthouse on PDP. Plan for skeleton states.
 
 ---

--- a/headless-poc/README.md
+++ b/headless-poc/README.md
@@ -46,7 +46,8 @@ A working scaffold that demonstrates Option C from `docs/webflow-integration-inv
 | `sync/worker/` | Cloudflare Worker — same upsert logic but driven by Shopify webhooks for near-real-time. Replaces polling in production. See `sync/worker/README.md`. |
 | `customer-account/` | Customer Account API client (OAuth 2.0 + PKCE). Login, "my account" greeting, order history. See `customer-account/README.md`. |
 | `tests/` | Playwright e2e suite — PDP renders, add-to-cart, drawer persistence, checkout redirect, JSON-LD presence. Runs against a live staging URL. |
-| `webflow-setup.md` | Step-by-step setup walkthrough. |
+| `local-preview/` | Static HTML harness that simulates a Webflow site so you can iterate on the appearance/behavior locally **without paying for Webflow yet**. Run `python3 -m http.server 8000` from `headless-poc/`, open <http://localhost:8000/local-preview/>. See `local-preview/README.md`. |
+| `webflow-setup.md` | Step-by-step setup walkthrough for the actual Webflow site. |
 | `repo-strategy.md` | Recommendation on whether the headless frontend belongs in this repo or a new one (TL;DR: new repo). |
 
 ## Quickstart
@@ -71,6 +72,9 @@ A working scaffold that demonstrates Option C from `docs/webflow-integration-inv
 | Concern | Where |
 |---|---|
 | Multi-currency / Markets | `omniflex-headless.js` resolves country + language at boot from `<meta>`/`<html lang>`/`navigator.language` and threads them into every Storefront query via `@inContext`. The cart is created with matching `buyerIdentity.countryCode`. |
+| Predictive search | `data-of-search` mount → debounced live results from `predictiveSearch` query (products, collections, suggested queries). |
+| Refresh-token rotation | Customer Account module exchanges refresh tokens transparently and retries on 401, with in-flight de-duping so parallel calls only hit the token endpoint once. |
+| Local preview | `local-preview/` static HTML harness — see `local-preview/README.md`. |
 | JSON-LD SEO | `injectProductJsonLd()` in `omniflex-headless.js` writes a `Product` schema (with per-variant `offers`) into `<head>` after PDP load. |
 | Webhook-driven sync | `sync/worker/worker.mjs` — Cloudflare Worker, validates HMAC, dispatches on Shopify webhook topics, runs the actual Webflow write in `ctx.waitUntil`. |
 | Customer accounts | `customer-account/customer-account.js` — full OAuth 2.0 + PKCE against the Customer Account API. Login state in header, order history page, logout that also clears Shop Pay sessions. |

--- a/headless-poc/README.md
+++ b/headless-poc/README.md
@@ -36,15 +36,18 @@ A working scaffold that demonstrates Option C from `docs/webflow-integration-inv
 
 | File | Purpose |
 |---|---|
-| `omniflex-headless.js` | Single ES module loaded by Webflow. Auto-mounts on `data-of-*` attributes for PDP, PLP, cart drawer, add-to-cart. Exposes a `window.OmniFlex` API for ad-hoc page-level scripts. |
+| `omniflex-headless.js` | Single ES module loaded by Webflow. Auto-mounts on `data-of-*` attributes for PDP, PLP, cart drawer, add-to-cart. Multi-currency via `@inContext`. Injects JSON-LD on PDP. Exposes a `window.OmniFlex` API for ad-hoc page-level scripts. |
 | `omniflex-headless.css` | Minimal default styles. Class names are namespaced `of-*` so Webflow CSS can override. |
 | `webflow-embeds/site-wide-head.html` | The script + style tags + config `<meta>`s to paste into Webflow's site-wide custom code. |
 | `webflow-embeds/pdp-template.html` | Snippet for the Webflow Products CMS Template Page. |
 | `webflow-embeds/plp-template.html` | Two PLP variants — CMS-bound or script-rendered. |
 | `webflow-embeds/cart-icon.html` | Cart toggle attributes for the header. |
-| `sync/sync.mjs` | Node 20+ script that mirrors Shopify products into a Webflow CMS Collection. |
-| `sync/.env.example` | Required env vars for the sync. |
+| `sync/sync.mjs` | Node 20+ polling script. Mirrors Shopify products into a Webflow CMS Collection. Use for first import and as a CI reconciliation check. |
+| `sync/worker/` | Cloudflare Worker — same upsert logic but driven by Shopify webhooks for near-real-time. Replaces polling in production. See `sync/worker/README.md`. |
+| `customer-account/` | Customer Account API client (OAuth 2.0 + PKCE). Login, "my account" greeting, order history. See `customer-account/README.md`. |
+| `tests/` | Playwright e2e suite — PDP renders, add-to-cart, drawer persistence, checkout redirect, JSON-LD presence. Runs against a live staging URL. |
 | `webflow-setup.md` | Step-by-step setup walkthrough. |
+| `repo-strategy.md` | Recommendation on whether the headless frontend belongs in this repo or a new one (TL;DR: new repo). |
 
 ## Quickstart
 
@@ -63,17 +66,27 @@ A working scaffold that demonstrates Option C from `docs/webflow-integration-inv
 7. Add a header cart link with `data-of-cart-toggle` and a `<span data-of-cart-count>`.
 8. Open the staging URL, add a product to cart, click checkout, complete a Bogus-Gateway test order.
 
-## What's intentionally out of scope (for now)
+## What's now included (was deferred in v1)
+
+| Concern | Where |
+|---|---|
+| Multi-currency / Markets | `omniflex-headless.js` resolves country + language at boot from `<meta>`/`<html lang>`/`navigator.language` and threads them into every Storefront query via `@inContext`. The cart is created with matching `buyerIdentity.countryCode`. |
+| JSON-LD SEO | `injectProductJsonLd()` in `omniflex-headless.js` writes a `Product` schema (with per-variant `offers`) into `<head>` after PDP load. |
+| Webhook-driven sync | `sync/worker/worker.mjs` — Cloudflare Worker, validates HMAC, dispatches on Shopify webhook topics, runs the actual Webflow write in `ctx.waitUntil`. |
+| Customer accounts | `customer-account/customer-account.js` — full OAuth 2.0 + PKCE against the Customer Account API. Login state in header, order history page, logout that also clears Shop Pay sessions. |
+| Playwright e2e | `tests/` — five smoke tests (PDP, add-to-cart, persistence, checkout redirect, JSON-LD). Skips when `BASE_URL` is unset. |
+
+## What's still out of scope
 
 | Concern | Plan |
 |---|---|
-| Customer accounts (login/orders) | Redirect to Shopify on a separate route. The Customer Account API requires its own OAuth dance and a custom React-ish app to render. |
-| Multi-currency / Markets | Storefront API supports `@inContext(country: ...)` directives. Add country detection + presentment-currency handling once the single-locale flow is solid. |
 | Predictive search / facets | Replace with Algolia / Searchanise / Shopify Search & Discovery extension. |
-| Subscriptions / selling plans | Renders only at Shopify checkout — works as long as the redirect to `checkoutUrl` is preserved. The drawer does not yet show selling-plan UI. |
-| Webhook-driven sync | Today the sync polls. Migrate to Shopify webhooks (`products/update`, `inventory_levels/update`) hitting a Cloudflare Worker for near-real-time. |
-| Cart line item properties / gift recipient | Not yet wired in `addLine`. The Storefront API supports `attributes` on `CartLineInput` — easy add. |
-| Build pipeline / minification | Script ships as readable ES2022 from the repo. For production, bundle + pin to a commit SHA on jsDelivr. |
+| Subscriptions / selling plans UI | Renders at Shopify checkout — already works via the `checkoutUrl` redirect. Drawer does not yet expose selling-plan selection. |
+| Cart line item properties / gift recipient | The Storefront API supports `attributes` on `CartLineInput` — easy add when the form fields are needed. |
+| Build pipeline / minification | Script ships as readable ES2022 from the repo. For production, bundle + pin to a commit SHA on jsDelivr (or move to a real CDN — see `repo-strategy.md`). |
+| Address book CRUD on `/account` | Customer Account API supports it; UI not yet built. |
+| Refresh-token handling | Tokens expire ~1h; the customer is silently logged out and prompted to re-authenticate. |
+| Visual regression tests | Add `toHaveScreenshot()` once the design is locked. |
 
 ## Known limits and gotchas
 

--- a/headless-poc/README.md
+++ b/headless-poc/README.md
@@ -1,0 +1,98 @@
+# Headless Webflow + Shopify — Proof of Concept
+
+A working scaffold that demonstrates Option C from `docs/webflow-integration-investigation.md`: Webflow as the rendering frontend, Shopify as the commerce backend, talking via the Shopify Storefront API, with a one‑way sync that mirrors the product catalog into Webflow CMS so Webflow Designer can build CMS‑templated pages.
+
+## Architecture
+
+```
+                            ┌────────────────────────────────────┐
+                            │           Webflow site              │
+                            │                                     │
+   designer-built pages ──> │  CMS-templated PDP / PLP            │
+                            │  (uses Webflow CMS items as layout) │
+                            │                                     │
+                            │  + omniflex-headless.js (mounted)   │
+                            └────────┬────────────────────────────┘
+                                     │  live cart, variant lookup,
+                                     │  inventory via fetch() →
+                                     ▼
+                            ┌────────────────────────────────────┐
+                            │   Shopify Storefront API (public)   │
+                            │   shopify.com/api/<v>/graphql.json  │
+                            └────────────────────────────────────┘
+                                     ▲                           ▲
+                                     │ checkoutUrl redirect       │ Admin API
+                                     │                           │ (private)
+   customers ────────────────────────┘                           │
+                                                                 │
+                            ┌────────────────────────────────────┴───┐
+                            │  sync.mjs (Node / Cloudflare Worker)    │
+                            │  Shopify products → Webflow CMS items   │
+                            │  (cron, webhook-driven, or manual)      │
+                            └─────────────────────────────────────────┘
+```
+
+## What's in the box
+
+| File | Purpose |
+|---|---|
+| `omniflex-headless.js` | Single ES module loaded by Webflow. Auto-mounts on `data-of-*` attributes for PDP, PLP, cart drawer, add-to-cart. Exposes a `window.OmniFlex` API for ad-hoc page-level scripts. |
+| `omniflex-headless.css` | Minimal default styles. Class names are namespaced `of-*` so Webflow CSS can override. |
+| `webflow-embeds/site-wide-head.html` | The script + style tags + config `<meta>`s to paste into Webflow's site-wide custom code. |
+| `webflow-embeds/pdp-template.html` | Snippet for the Webflow Products CMS Template Page. |
+| `webflow-embeds/plp-template.html` | Two PLP variants — CMS-bound or script-rendered. |
+| `webflow-embeds/cart-icon.html` | Cart toggle attributes for the header. |
+| `sync/sync.mjs` | Node 20+ script that mirrors Shopify products into a Webflow CMS Collection. |
+| `sync/.env.example` | Required env vars for the sync. |
+| `webflow-setup.md` | Step-by-step setup walkthrough. |
+
+## Quickstart
+
+1. Read `webflow-setup.md` once end-to-end before clicking anything.
+2. Create the Shopify Storefront and Admin API tokens.
+3. Create the Webflow site + Products CMS collection with the field schema in §3 of the setup guide.
+4. Paste `webflow-embeds/site-wide-head.html` into Webflow's site-wide custom code, with your shop domain and Storefront token filled in.
+5. Run the sync:
+   ```bash
+   cd headless-poc/sync
+   cp .env.example .env  # fill in tokens
+   npm run sync:dry       # preview changes
+   npm run sync           # write to Webflow
+   ```
+6. Add `data-of-product="{{ Slug }}"` to a div on the Products CMS template page and publish.
+7. Add a header cart link with `data-of-cart-toggle` and a `<span data-of-cart-count>`.
+8. Open the staging URL, add a product to cart, click checkout, complete a Bogus-Gateway test order.
+
+## What's intentionally out of scope (for now)
+
+| Concern | Plan |
+|---|---|
+| Customer accounts (login/orders) | Redirect to Shopify on a separate route. The Customer Account API requires its own OAuth dance and a custom React-ish app to render. |
+| Multi-currency / Markets | Storefront API supports `@inContext(country: ...)` directives. Add country detection + presentment-currency handling once the single-locale flow is solid. |
+| Predictive search / facets | Replace with Algolia / Searchanise / Shopify Search & Discovery extension. |
+| Subscriptions / selling plans | Renders only at Shopify checkout — works as long as the redirect to `checkoutUrl` is preserved. The drawer does not yet show selling-plan UI. |
+| Webhook-driven sync | Today the sync polls. Migrate to Shopify webhooks (`products/update`, `inventory_levels/update`) hitting a Cloudflare Worker for near-real-time. |
+| Cart line item properties / gift recipient | Not yet wired in `addLine`. The Storefront API supports `attributes` on `CartLineInput` — easy add. |
+| Build pipeline / minification | Script ships as readable ES2022 from the repo. For production, bundle + pin to a commit SHA on jsDelivr. |
+
+## Known limits and gotchas
+
+1. **Live inventory is fetched at PDP load**, not from Webflow CMS. The synced `in-stock` field is a coarse boolean useful only for filtering in PLP queries.
+2. **Webflow CMS caps at 10K items**. With 28 locales × N products this becomes a hard ceiling — this PoC syncs a single locale; multi-locale would require either a separate Webflow site per locale or storing all locales in one item with locale-keyed fields.
+3. **Checkout always redirects to Shopify** (`*.myshopify.com/checkout` or your configured checkout domain). This is not optional with the Storefront API and is a feature, not a bug — Shopify Functions, Shop Pay, fraud rules, and tax all live there.
+4. **The script is unminified** and served from jsDelivr against a branch. **Pin to a commit SHA** before any production traffic, otherwise a future commit on the branch will silently change the production storefront.
+5. **No SSR**: pages are crawled by Googlebot client-side. Shopify metadata for SEO (price, availability via `Product` JSON-LD) needs to be emitted by the script as a `<script type="application/ld+json">` injection. Not yet wired.
+6. **No tests**: this is a PoC. A production rollout needs Playwright tests at minimum on the add-to-cart and checkout-redirect paths, plus a sync dry-run smoke test in CI.
+
+## Validating end-to-end
+
+I (Claude) cannot validate this against a real Webflow site or real Shopify store from this session — the code is unrun. Before declaring the PoC working you'll need to:
+
+- [ ] Sync runs without errors against a live Webflow CMS collection
+- [ ] PDP loads a real Shopify product on a Webflow staging URL
+- [ ] Variant selection updates price and add-to-cart variant ID
+- [ ] Add to cart populates the drawer and persists across page reload
+- [ ] Checkout link redirects to Shopify's hosted checkout with the cart contents intact
+- [ ] A Bogus-Gateway test order completes and appears in Shopify orders
+
+Once those check out, the next iteration is wiring the rest of the catalog (search, account redirect, multi-currency) and replacing polling sync with webhooks.

--- a/headless-poc/customer-account/README.md
+++ b/headless-poc/customer-account/README.md
@@ -1,0 +1,60 @@
+# Customer Account API integration
+
+Customer login, "my account" greeting, and order history — all powered by Shopify's Customer Account API (the post-2024 replacement for Storefront API customer fields).
+
+## Why this is its own module
+
+- The Customer Account API is a **separate API endpoint** from the Storefront API and uses a separate auth model (OAuth 2.0 + PKCE).
+- It is mandatory for any flow that depends on the customer's identity — including matching orders, addresses, or purchase history. The legacy Storefront customer fields are deprecated.
+- It opens a popup-or-redirect to a Shopify-hosted login page (the same one Shop Pay uses), so customers reuse their existing Shop credentials. There is no password stored in the Webflow site.
+
+## Required Shopify config
+
+1. Shopify admin → **Settings** → **Customer accounts** → **Settings** → switch to **New customer accounts** if not already
+2. Shopify admin → **Hydrogen → Customer Account API** OR via the [Headless Storefront app](https://apps.shopify.com/headless), enable **Customer Account API**
+3. Configure the **Application URL** as `https://www.<your-webflow-site>` and the **Callback URI** as `https://www.<your-webflow-site>/account/callback`
+4. Note the **Customer Account API client ID** (starts with `shp_`) and the **Shop ID** (numeric, in the URL when viewing settings, or via Admin API `shop { id }`)
+
+## Webflow setup
+
+1. Create three pages in Webflow:
+   - `/account` — has elements with `data-of-account-login` and `data-of-account-orders` attributes
+   - `/account/callback` — must contain a single element with `data-of-account-callback`. The OAuth redirect lands here.
+   - (Optional) `/account/login` — a button with `data-of-account-login-btn` for explicit login entry points
+2. Add to **Site Settings → Custom Code → Inside `<head>`** (in addition to the storefront tags):
+   ```html
+   <meta name="of-account-shop-id"      content="123456789">
+   <meta name="of-account-client-id"    content="shp_xxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+   <meta name="of-account-redirect-uri" content="https://www.<your-webflow-site>/account/callback">
+
+   <script type="module"
+     src="https://cdn.jsdelivr.net/gh/OmniFlexFitness/OmniFlex-Shopify-Theme@<sha>/headless-poc/customer-account/customer-account.js"></script>
+   ```
+3. Publish to a real domain. **The callback URI must match the publicly reachable URL exactly**, including protocol and any trailing slash. The Shopify webflow.io subdomain is fine for development; production should be on a custom domain so the callback matches.
+
+## What's exposed
+
+- `data-of-account-login` element → renders "Log in" or "Hi <first name>" + "Log out" depending on auth state
+- `data-of-account-orders` element → renders the customer's last 25 orders (paginated via the Customer Account API)
+- `window.OmniFlexAccount.login()` / `.logout()` / `.getToken()` / `.customerGql(query, vars)` for ad-hoc page scripts (e.g. checking auth state in a header)
+
+## Security notes (read before production)
+
+1. **Tokens are stored in `localStorage`.** This is acceptable for a CMS-only Webflow site because there is no server-side rendering and no backend that could put them in `httpOnly` cookies. **For higher security postures (regulated industries, PCI scope), proxy the OAuth callback through a Cloudflare Worker that issues an `httpOnly` session cookie and proxies subsequent Customer Account API requests.** This module does not do that.
+2. **PKCE is mandatory** — Shopify's Customer Account API rejects the implicit flow. The module generates a fresh verifier per login and validates `state` to prevent CSRF.
+3. **Tokens expire in ~1 hour.** The module currently does not auto-refresh; the customer is silently logged out and prompted to log in again. Refresh-token handling is a sensible v2 addition.
+4. **Logout calls Shopify's `oauth/logout` endpoint** so Shop Pay-linked sessions are also cleared. Without this, signing out of Webflow would leave the customer signed into Shop Pay on shopify.com.
+
+## Coexistence with the Storefront client
+
+The two modules are independent — neither requires the other. The login button can sit on a Webflow page that has no products, and the storefront client can render PDPs without ever loading this module. Recommended pattern: include both site-wide so the header shows live cart count *and* live login state on every page.
+
+## What's NOT included in this PoC
+
+- Address book CRUD (the Customer Account API has full mutations; UI not built)
+- Editing customer profile (first/last name, default address)
+- Re-order from order detail
+- Order cancellation / refund request
+- Password reset / email verification flows (these are Shopify-hosted on the OAuth screens — no work needed)
+
+These are all straightforward extensions of `customer-account.js` once the OAuth flow is verified end-to-end.

--- a/headless-poc/customer-account/customer-account.js
+++ b/headless-poc/customer-account/customer-account.js
@@ -1,0 +1,311 @@
+/**
+ * Shopify Customer Account API client — OAuth 2.0 + PKCE.
+ *
+ * Drop-in companion to omniflex-headless.js. Mounts on:
+ *   [data-of-account-login]   → renders "Log in" / "Log out" + greeting
+ *   [data-of-account-orders]  → renders the customer's order history
+ *   [data-of-account-callback] → MUST exist on the configured redirect path
+ *
+ * Required <meta> tags (in addition to those for the storefront client):
+ *   <meta name="of-account-shop-id"     content="123456789">  // Shopify shop ID (numeric)
+ *   <meta name="of-account-client-id"   content="shp_xxxxx">  // Customer Account API client ID
+ *   <meta name="of-account-redirect-uri" content="https://www.example.com/account/callback">
+ *
+ * Why the new Customer Account API and not the legacy Storefront customer
+ * fields: Shopify deprecated unauthenticated_write_customers in favor of a
+ * dedicated identity provider that issues OAuth tokens scoped to a single
+ * customer. New Customer Accounts are mandatory for Shop Pay sign-in and
+ * for most apps that depend on customer identity.
+ *
+ * Reference: https://shopify.dev/docs/api/customer
+ */
+
+const meta = (n) => document.querySelector(`meta[name="${n}"]`)?.content;
+
+const SHOP_ID = meta('of-account-shop-id');
+const CLIENT_ID = meta('of-account-client-id');
+const REDIRECT_URI = meta('of-account-redirect-uri');
+
+const AUTH_BASE = SHOP_ID ? `https://shopify.com/${SHOP_ID}/account` : null;
+const AUTH_URL = AUTH_BASE ? `${AUTH_BASE}/oauth/authorize` : null;
+const TOKEN_URL = AUTH_BASE ? `${AUTH_BASE}/oauth/token` : null;
+const LOGOUT_URL = AUTH_BASE ? `${AUTH_BASE}/oauth/logout` : null;
+const API_URL = AUTH_BASE ? `${AUTH_BASE}/customer/api/2025-01/graphql` : null;
+
+const SCOPES = ['openid', 'email', 'customer-account-api:full'].join(' ');
+
+// --------------------------------------------------------------------------
+// PKCE
+// --------------------------------------------------------------------------
+
+function base64UrlEncode(bytes) {
+  return btoa(String.fromCharCode(...new Uint8Array(bytes)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function randomString(len = 64) {
+  const arr = new Uint8Array(len);
+  crypto.getRandomValues(arr);
+  return base64UrlEncode(arr);
+}
+
+async function sha256(text) {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+  return base64UrlEncode(new Uint8Array(buf));
+}
+
+// --------------------------------------------------------------------------
+// Token storage
+// --------------------------------------------------------------------------
+
+const TOKEN_KEY = 'of-customer-token';
+const PKCE_KEY = 'of-pkce-verifier';
+const STATE_KEY = 'of-oauth-state';
+
+function getToken() {
+  try {
+    const raw = localStorage.getItem(TOKEN_KEY);
+    if (!raw) return null;
+    const tok = JSON.parse(raw);
+    if (tok.expires_at && Date.now() > tok.expires_at - 30_000) return null;
+    return tok;
+  } catch {
+    return null;
+  }
+}
+
+function setToken(tok) {
+  if (!tok) {
+    localStorage.removeItem(TOKEN_KEY);
+    return;
+  }
+  // Tokens are bearer tokens — localStorage is acceptable for a CMS-only
+  // frontend, but a server-rendered architecture should keep them in
+  // httpOnly cookies. Document this trade-off in the README.
+  const expires_at = Date.now() + (tok.expires_in ?? 3600) * 1000;
+  localStorage.setItem(TOKEN_KEY, JSON.stringify({ ...tok, expires_at }));
+}
+
+// --------------------------------------------------------------------------
+// OAuth flow
+// --------------------------------------------------------------------------
+
+async function login() {
+  if (!CLIENT_ID || !REDIRECT_URI || !AUTH_URL) {
+    console.error('[omniflex/account] missing config');
+    return;
+  }
+  const verifier = randomString(64);
+  const challenge = await sha256(verifier);
+  const state = randomString(32);
+  sessionStorage.setItem(PKCE_KEY, verifier);
+  sessionStorage.setItem(STATE_KEY, state);
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    scope: SCOPES,
+    response_type: 'code',
+    redirect_uri: REDIRECT_URI,
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+  location.href = `${AUTH_URL}?${params.toString()}`;
+}
+
+async function exchangeCode() {
+  const url = new URL(location.href);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  if (!code) return null;
+  const expected = sessionStorage.getItem(STATE_KEY);
+  if (!state || state !== expected) {
+    console.error('[omniflex/account] state mismatch');
+    return null;
+  }
+  const verifier = sessionStorage.getItem(PKCE_KEY);
+  sessionStorage.removeItem(PKCE_KEY);
+  sessionStorage.removeItem(STATE_KEY);
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    code,
+    code_verifier: verifier,
+  });
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) {
+    console.error('[omniflex/account] token exchange failed', await res.text());
+    return null;
+  }
+  const tok = await res.json();
+  setToken(tok);
+  // Strip the ?code= from the URL so a refresh doesn't re-trigger exchange.
+  url.searchParams.delete('code');
+  url.searchParams.delete('state');
+  history.replaceState(null, '', url.toString());
+  return tok;
+}
+
+function logout() {
+  const tok = getToken();
+  setToken(null);
+  if (tok && LOGOUT_URL) {
+    const params = new URLSearchParams({
+      id_token_hint: tok.id_token ?? '',
+      post_logout_redirect_uri: location.origin,
+    });
+    location.href = `${LOGOUT_URL}?${params.toString()}`;
+  } else {
+    location.reload();
+  }
+}
+
+// --------------------------------------------------------------------------
+// Customer Account GraphQL
+// --------------------------------------------------------------------------
+
+async function customerGql(query, variables = {}) {
+  const tok = getToken();
+  if (!tok) throw new Error('not authenticated');
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: tok.access_token,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`customer api ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  if (json.errors) throw new Error(JSON.stringify(json.errors));
+  return json.data;
+}
+
+const Q_VIEWER = `query { customer { firstName lastName emailAddress { emailAddress } } }`;
+
+const Q_ORDERS = `query Orders($first: Int!) {
+  customer {
+    orders(first: $first, sortKey: PROCESSED_AT, reverse: true) {
+      nodes {
+        id
+        name
+        processedAt
+        financialStatus
+        fulfillmentStatus
+        totalPrice { amount currencyCode }
+        lineItems(first: 10) {
+          nodes {
+            title
+            quantity
+            image { url altText }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+// --------------------------------------------------------------------------
+// Render
+// --------------------------------------------------------------------------
+
+function money(m) {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency: m.currencyCode })
+    .format(parseFloat(m.amount));
+}
+
+async function renderLogin(host) {
+  host.innerHTML = '';
+  const tok = getToken();
+  if (!tok) {
+    host.innerHTML = '<button data-of-account-login-btn>Log in</button>';
+    host.querySelector('[data-of-account-login-btn]')
+      .addEventListener('click', () => login());
+    return;
+  }
+  try {
+    const { customer } = await customerGql(Q_VIEWER);
+    host.innerHTML = `
+      <span>Hi ${customer.firstName ?? customer.emailAddress.emailAddress}</span>
+      <button data-of-account-logout-btn>Log out</button>
+    `;
+    host.querySelector('[data-of-account-logout-btn]')
+      .addEventListener('click', () => logout());
+  } catch (e) {
+    console.error(e);
+    setToken(null);
+    host.innerHTML = '<button data-of-account-login-btn>Log in</button>';
+    host.querySelector('[data-of-account-login-btn]')
+      .addEventListener('click', () => login());
+  }
+}
+
+async function renderOrders(host) {
+  if (!getToken()) {
+    host.innerHTML = '<p>Please <a href="#" data-of-account-login-btn>log in</a> to view your orders.</p>';
+    host.querySelector('[data-of-account-login-btn]')
+      .addEventListener('click', (e) => { e.preventDefault(); login(); });
+    return;
+  }
+  try {
+    const data = await customerGql(Q_ORDERS, { first: 25 });
+    const orders = data.customer.orders.nodes;
+    if (orders.length === 0) {
+      host.innerHTML = '<p>No orders yet.</p>';
+      return;
+    }
+    host.innerHTML = `
+      <ul class="of-orders">
+        ${orders.map((o) => `
+          <li class="of-orders__item">
+            <header>
+              <strong>${o.name}</strong>
+              <time>${new Date(o.processedAt).toLocaleDateString()}</time>
+              <span>${money(o.totalPrice)}</span>
+              <span class="of-orders__status">${o.fulfillmentStatus ?? o.financialStatus ?? ''}</span>
+            </header>
+            <ul class="of-orders__lines">
+              ${o.lineItems.nodes.map((l) => `
+                <li>
+                  <img src="${l.image?.url ?? ''}" alt="${l.image?.altText ?? ''}" width="48" height="48">
+                  ${l.title} × ${l.quantity}
+                </li>`).join('')}
+            </ul>
+          </li>`).join('')}
+      </ul>`;
+  } catch (e) {
+    console.error(e);
+    host.innerHTML = '<p>Could not load orders.</p>';
+  }
+}
+
+// --------------------------------------------------------------------------
+// Mount
+// --------------------------------------------------------------------------
+
+async function mount() {
+  // If we're on the configured callback path, exchange code first.
+  if (document.querySelector('[data-of-account-callback]')) {
+    await exchangeCode();
+  }
+  for (const host of document.querySelectorAll('[data-of-account-login]')) {
+    renderLogin(host);
+  }
+  for (const host of document.querySelectorAll('[data-of-account-orders]')) {
+    renderOrders(host);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', mount);
+} else {
+  mount();
+}
+
+window.OmniFlexAccount = { login, logout, getToken, customerGql };

--- a/headless-poc/customer-account/customer-account.js
+++ b/headless-poc/customer-account/customer-account.js
@@ -64,16 +64,63 @@ const TOKEN_KEY = 'of-customer-token';
 const PKCE_KEY = 'of-pkce-verifier';
 const STATE_KEY = 'of-oauth-state';
 
-function getToken() {
+function readToken() {
   try {
     const raw = localStorage.getItem(TOKEN_KEY);
-    if (!raw) return null;
-    const tok = JSON.parse(raw);
-    if (tok.expires_at && Date.now() > tok.expires_at - 30_000) return null;
-    return tok;
+    return raw ? JSON.parse(raw) : null;
   } catch {
     return null;
   }
+}
+
+function getToken() {
+  const tok = readToken();
+  if (!tok) return null;
+  if (tok.expires_at && Date.now() > tok.expires_at - 30_000) return null;
+  return tok;
+}
+
+let refreshInFlight = null;
+
+async function refreshToken() {
+  // Coalesce parallel callers so we only hit the token endpoint once.
+  if (refreshInFlight) return refreshInFlight;
+  const tok = readToken();
+  if (!tok?.refresh_token) return null;
+  refreshInFlight = (async () => {
+    try {
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: CLIENT_ID,
+        refresh_token: tok.refresh_token,
+      });
+      const res = await fetch(TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+      if (!res.ok) {
+        // Refresh tokens can be revoked or expired — clear and force re-login.
+        setToken(null);
+        return null;
+      }
+      const fresh = await res.json();
+      // Shopify rotates refresh tokens on every refresh; preserve any field
+      // (id_token, scope) the new response doesn't repeat.
+      const merged = { ...tok, ...fresh };
+      setToken(merged);
+      return readToken();
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}
+
+async function getValidToken() {
+  const tok = getToken();
+  if (tok) return tok;
+  return refreshToken();
 }
 
 function setToken(tok) {
@@ -171,9 +218,9 @@ function logout() {
 // --------------------------------------------------------------------------
 
 async function customerGql(query, variables = {}) {
-  const tok = getToken();
+  let tok = await getValidToken();
   if (!tok) throw new Error('not authenticated');
-  const res = await fetch(API_URL, {
+  let res = await fetch(API_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -181,6 +228,21 @@ async function customerGql(query, variables = {}) {
     },
     body: JSON.stringify({ query, variables }),
   });
+  // If the server still rejects the bearer (token revoked between expiry
+  // check and request, clock skew, etc.) try one refresh + retry.
+  if (res.status === 401) {
+    const fresh = await refreshToken();
+    if (fresh) {
+      res = await fetch(API_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: fresh.access_token,
+        },
+        body: JSON.stringify({ query, variables }),
+      });
+    }
+  }
   if (!res.ok) throw new Error(`customer api ${res.status}: ${await res.text()}`);
   const json = await res.json();
   if (json.errors) throw new Error(JSON.stringify(json.errors));

--- a/headless-poc/local-preview/.gitignore
+++ b/headless-poc/local-preview/.gitignore
@@ -1,0 +1,1 @@
+config.local.js

--- a/headless-poc/local-preview/README.md
+++ b/headless-poc/local-preview/README.md
@@ -1,0 +1,103 @@
+# Local preview
+
+Static HTML harness that simulates a Webflow site with the headless script mounted, so you can iterate on the appearance and behavior **without paying for Webflow yet**. The same `data-of-*` markup conventions you'll use in Webflow Designer work here verbatim.
+
+## What's in here
+
+| Page | Demonstrates |
+|---|---|
+| `index.html`       | Header with cart toggle, links to the other pages. Stand-in for the Webflow homepage. |
+| `product.html`     | PDP — variant picker, price, add-to-cart, JSON-LD injection. Handle is editable in-page. |
+| `collection.html`  | PLP — script-rendered grid for a Shopify collection handle. |
+| `search.html`      | Predictive search input with live Storefront API results. |
+
+The cart drawer is shared across all pages (it's injected once into `<body>` by the script).
+
+## Prerequisites
+
+You need a **Shopify Storefront API public access token**. Same token used in the Webflow setup — see `../webflow-setup.md` § 1. The token is designed to be public; it's safe in client code. Just don't commit it to a public repo.
+
+You do **not** need a Webflow account, an Admin API token, or the sync script for the local preview. It talks directly to Shopify.
+
+## Run it
+
+The pages reference `../omniflex-headless.js` and `../omniflex-headless.css` by relative path, so the document root must be `headless-poc/`. Any static HTTP server works; pick whichever you have:
+
+```bash
+# Option 1 — Python (already installed on macOS/Linux)
+cd headless-poc
+python3 -m http.server 8000
+
+# Option 2 — Node
+cd headless-poc
+npx --yes serve -l 8000 .
+
+# Option 3 — PHP (if you have it lying around)
+cd headless-poc
+php -S localhost:8000
+```
+
+Then open <http://localhost:8000/local-preview/>.
+
+> **Don't open the HTML files with `file://`** — fetch() and ES modules are blocked by the browser under `file://` for CORS reasons. You'll see "Storefront API 0" or "Failed to fetch" in the console.
+
+## Configure the token
+
+Two ways. Pick one.
+
+### A. Quick: edit the meta tags in each HTML file
+
+Open `index.html`, `product.html`, `collection.html`, `search.html` and replace:
+
+```html
+<meta name="of-shop"  content="REPLACE_WITH_YOUR.myshopify.com">
+<meta name="of-token" content="REPLACE_WITH_PUBLIC_STOREFRONT_TOKEN">
+```
+
+### B. Cleaner: use `config.local.js` (gitignored)
+
+```bash
+cp config.local.example.js config.local.js
+# edit config.local.js with your shop + token
+```
+
+This file is already in `.gitignore`, so accidental commits are blocked. The HTML pages load it via `<script src="./config.local.js" onerror="void 0">` — a 404 is silently ignored if you skip this step.
+
+## What you should see
+
+1. Visit <http://localhost:8000/local-preview/> → header with cart, three navigation cards
+2. Click **Product page** → enter a real product handle from your store → click **Load** → variant picker and price render
+3. Click **Add to cart** → cart drawer slides in from the right with the line item
+4. The header **Cart 1** badge updates live
+5. Reload the page → cart count is preserved (localStorage)
+6. Click the drawer's **Checkout** link → opens `*.myshopify.com/checkouts/<id>` in a new tab (your real Shopify-hosted checkout)
+7. Visit **Search**, type a query → live predictive search results
+
+If any step fails, open DevTools → Console. Common failures:
+- **`Storefront API 401`**: wrong token, or token belongs to a different store
+- **`Storefront API 403`**: the Storefront app is missing a scope — go back to `../webflow-setup.md` § 1
+- **CORS error**: you opened the HTML via `file://`. Run a server.
+- **`product` returns null**: the handle in the input doesn't exist in your store
+
+## Hot-reload
+
+The simple HTTP servers above don't auto-refresh on file edits. If you want hot reload, use `npx --yes browser-sync start --server . --files "**/*.{js,css,html}"` from `headless-poc/` — but it's not necessary for casual iteration since `Cmd-R` after a save is fine.
+
+## Mapping local preview → Webflow
+
+When the local pages look right, recreate them in Webflow:
+
+| Local element | Webflow equivalent |
+|---|---|
+| `<a data-of-cart-toggle>` in `demo-header` | A Link Block in the Webflow header with the `data-of-cart-toggle` custom attribute |
+| `<div data-of-product="...">` on `product.html` | A Div Block on the Products CMS Template Page with `data-of-product` bound to the **Slug** field |
+| `<div data-of-collection="...">` on `collection.html` | Either an embed (script-rendered) or a Webflow CMS Collection List bound to the synced Products collection |
+| `<div data-of-search>` on `search.html` | An HTML Embed in the Webflow header |
+
+The script does not care whether the markup came from Webflow or from these local files — it scans for `data-of-*` attributes either way. That's what makes this preview faithful.
+
+## Limits of the local preview
+
+- **No Webflow Designer styles**: this harness uses a tiny `demo.css` for chrome (header, banner). Once you build the design in Webflow, the actual styles will come from there.
+- **No customer accounts**: the OAuth callback URL must be a real public URL Shopify can redirect to. Use `ngrok http 8000` if you need to test the OAuth flow locally — set the `of-account-redirect-uri` meta to the ngrok URL and add it to the Shopify Customer Account API allowed redirect URIs.
+- **No CMS sync**: the polling sync (`sync/sync.mjs`) and the webhook worker only matter once you have a real Webflow site. They're irrelevant for this local harness.

--- a/headless-poc/local-preview/_head.html
+++ b/headless-poc/local-preview/_head.html
@@ -1,0 +1,18 @@
+<!--
+  Reference partial. Each page below copies these tags into its own <head>.
+  Only edit one — keep the rest in sync.
+
+  The "of-shop" and "of-token" values must be the OmniFlex Shopify store
+  and a public Storefront API access token. The token is safe to commit
+  for *your* fork running locally, but DO NOT commit a real token to a
+  public branch. Use config.local.js to keep it out of git (see below).
+-->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="of-shop"        content="REPLACE_WITH_YOUR.myshopify.com">
+<meta name="of-token"       content="REPLACE_WITH_PUBLIC_STOREFRONT_TOKEN">
+<meta name="of-api-version" content="2025-01">
+<link rel="stylesheet" href="../omniflex-headless.css">
+<link rel="stylesheet" href="./demo.css">
+<script type="module" src="./config.local.js" onerror="void 0"></script>
+<script type="module" src="../omniflex-headless.js"></script>

--- a/headless-poc/local-preview/collection.html
+++ b/headless-poc/local-preview/collection.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <title>Collection · OmniFlex local preview</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="of-shop"        content="REPLACE_WITH_YOUR.myshopify.com">
+  <meta name="of-token"       content="REPLACE_WITH_PUBLIC_STOREFRONT_TOKEN">
+  <meta name="of-api-version" content="2025-01">
+  <link rel="stylesheet" href="../omniflex-headless.css">
+  <link rel="stylesheet" href="./demo.css">
+  <script type="module" src="./config.local.js" onerror="void 0"></script>
+  <script type="module" src="../omniflex-headless.js"></script>
+</head>
+<body>
+  <div class="demo-banner">
+    PLP demo (script-rendered variant). Change the handle below; "all" works on most stores.
+  </div>
+
+  <header class="demo-header">
+    <a href="./index.html" class="demo-header__brand">OMNIFLEX</a>
+    <nav class="demo-nav">
+      <a href="./collection.html">Shop</a>
+      <a href="./product.html">Product</a>
+      <a href="./search.html">Search</a>
+    </nav>
+    <a href="#" class="demo-cart" data-of-cart-toggle>
+      Cart <span data-of-cart-count>0</span>
+    </a>
+  </header>
+
+  <main>
+    <p>
+      <label>Collection handle:
+        <input class="demo-input" id="handle-input" value="all">
+      </label>
+      <button id="reload-btn">Load</button>
+    </p>
+
+    <div data-of-collection="all" data-of-limit="24" id="collection-mount"></div>
+  </main>
+
+  <script type="module">
+    const handleInput = document.getElementById('handle-input');
+    const reloadBtn = document.getElementById('reload-btn');
+    const url = new URL(location.href);
+    const initial = url.searchParams.get('handle');
+    if (initial) {
+      handleInput.value = initial;
+      document.getElementById('collection-mount').setAttribute('data-of-collection', initial);
+    }
+    reloadBtn.addEventListener('click', () => {
+      const h = handleInput.value.trim();
+      url.searchParams.set('handle', h);
+      location.href = url.toString();
+    });
+  </script>
+</body>
+</html>

--- a/headless-poc/local-preview/config.local.example.js
+++ b/headless-poc/local-preview/config.local.example.js
@@ -1,0 +1,21 @@
+/*
+ * Copy to config.local.js and fill in. config.local.js is gitignored.
+ *
+ * Sets <meta> values at runtime so the storefront token never lands in
+ * committed HTML. Loads BEFORE omniflex-headless.js (see _head.html).
+ */
+const set = (name, content) => {
+  let m = document.querySelector(`meta[name="${name}"]`);
+  if (!m) {
+    m = document.createElement('meta');
+    m.name = name;
+    document.head.appendChild(m);
+  }
+  m.content = content;
+};
+
+set('of-shop',  'YOUR-STORE.myshopify.com');
+set('of-token', 'YOUR-PUBLIC-STOREFRONT-TOKEN');
+// Optional locale override:
+// set('of-country',  'US');
+// set('of-language', 'EN');

--- a/headless-poc/local-preview/demo.css
+++ b/headless-poc/local-preview/demo.css
@@ -1,0 +1,83 @@
+/* Demo-only chrome for local preview pages — not shipped to Webflow. */
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #111;
+  background: #fafafa;
+}
+.demo-banner {
+  background: #fff3a8;
+  color: #6b5800;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  text-align: center;
+  border-bottom: 1px solid #e6d966;
+}
+.demo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  background: #111;
+  color: #fff;
+}
+.demo-header__brand {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: inherit;
+}
+.demo-nav { display: flex; gap: 1rem; flex: 1; }
+.demo-nav a {
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.demo-nav a:hover { text-decoration: underline; }
+.demo-cart {
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.demo-cart [data-of-cart-count] {
+  display: inline-block;
+  margin-left: 0.25rem;
+  background: #fff;
+  color: #111;
+  border-radius: 999px;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+main { max-width: 1100px; margin: 2rem auto; padding: 0 1.5rem; }
+.demo-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  margin-top: 1.5rem;
+}
+.demo-grid a {
+  display: block;
+  padding: 1.5rem;
+  background: #fff;
+  border: 1px solid #eee;
+  text-decoration: none;
+  color: inherit;
+}
+.demo-grid a:hover { border-color: #111; }
+.demo-grid h2 { margin: 0 0 0.5rem; font-size: 1.125rem; }
+.demo-grid p { margin: 0; font-size: 0.875rem; opacity: 0.7; }
+.demo-input {
+  display: block;
+  width: 100%;
+  max-width: 24rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1rem;
+}

--- a/headless-poc/local-preview/index.html
+++ b/headless-poc/local-preview/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <title>OmniFlex headless · local preview</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="of-shop"        content="REPLACE_WITH_YOUR.myshopify.com">
+  <meta name="of-token"       content="REPLACE_WITH_PUBLIC_STOREFRONT_TOKEN">
+  <meta name="of-api-version" content="2025-01">
+  <link rel="stylesheet" href="../omniflex-headless.css">
+  <link rel="stylesheet" href="./demo.css">
+  <script type="module" src="./config.local.js" onerror="void 0"></script>
+  <script type="module" src="../omniflex-headless.js"></script>
+</head>
+<body>
+  <div class="demo-banner">
+    Local preview · simulating a Webflow site with the headless script mounted.
+    Replace the <code>of-token</code> meta (or use <code>config.local.js</code>) with a real Storefront API token.
+  </div>
+
+  <header class="demo-header">
+    <a href="./index.html" class="demo-header__brand">OMNIFLEX</a>
+    <nav class="demo-nav">
+      <a href="./collection.html">Shop</a>
+      <a href="./product.html">Product</a>
+      <a href="./search.html">Search</a>
+    </nav>
+    <a href="#" class="demo-cart" data-of-cart-toggle>
+      Cart <span data-of-cart-count>0</span>
+    </a>
+  </header>
+
+  <main>
+    <h1>Local preview</h1>
+    <p>
+      This page mirrors what your Webflow site will look like once the script is mounted.
+      The header above contains the cart toggle and live count badge that you'll add to the
+      Webflow Designer header. The links below open the other preview pages.
+    </p>
+
+    <div class="demo-grid">
+      <a href="./collection.html">
+        <h2>Collection page →</h2>
+        <p>PLP rendered from a Shopify collection handle.</p>
+      </a>
+      <a href="./product.html">
+        <h2>Product page →</h2>
+        <p>PDP with variant picker, JSON-LD, and add-to-cart.</p>
+      </a>
+      <a href="./search.html">
+        <h2>Predictive search →</h2>
+        <p>Live Storefront API search with debounced input.</p>
+      </a>
+    </div>
+  </main>
+</body>
+</html>

--- a/headless-poc/local-preview/product.html
+++ b/headless-poc/local-preview/product.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <title>Product · OmniFlex local preview</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="of-shop"        content="REPLACE_WITH_YOUR.myshopify.com">
+  <meta name="of-token"       content="REPLACE_WITH_PUBLIC_STOREFRONT_TOKEN">
+  <meta name="of-api-version" content="2025-01">
+  <link rel="stylesheet" href="../omniflex-headless.css">
+  <link rel="stylesheet" href="./demo.css">
+  <script type="module" src="./config.local.js" onerror="void 0"></script>
+  <script type="module" src="../omniflex-headless.js"></script>
+</head>
+<body>
+  <div class="demo-banner">
+    PDP demo. Change the handle below to any product handle that exists in your Shopify store.
+  </div>
+
+  <header class="demo-header">
+    <a href="./index.html" class="demo-header__brand">OMNIFLEX</a>
+    <nav class="demo-nav">
+      <a href="./collection.html">Shop</a>
+      <a href="./product.html">Product</a>
+      <a href="./search.html">Search</a>
+    </nav>
+    <a href="#" class="demo-cart" data-of-cart-toggle>
+      Cart <span data-of-cart-count>0</span>
+    </a>
+  </header>
+
+  <main>
+    <p>
+      <label>Handle:
+        <input class="demo-input" id="handle-input" value="example-product-handle">
+      </label>
+      <button id="reload-btn">Load</button>
+    </p>
+
+    <!-- This is the only Webflow-relevant markup on the page.
+         In Webflow Designer this would be a Div Block with the
+         data-of-product attribute bound to the CMS Slug field. -->
+    <div data-of-product="example-product-handle" id="product-mount"></div>
+  </main>
+
+  <script type="module">
+    // Local-preview-only convenience: let the demo input change the
+    // mounted handle without manually editing the URL. This script does
+    // NOT ship to Webflow.
+    const handleInput = document.getElementById('handle-input');
+    const reloadBtn = document.getElementById('reload-btn');
+    const url = new URL(location.href);
+    const initial = url.searchParams.get('handle');
+    if (initial) {
+      handleInput.value = initial;
+      document.getElementById('product-mount').setAttribute('data-of-product', initial);
+    }
+    reloadBtn.addEventListener('click', () => {
+      const h = handleInput.value.trim();
+      url.searchParams.set('handle', h);
+      location.href = url.toString();
+    });
+  </script>
+</body>
+</html>

--- a/headless-poc/local-preview/search.html
+++ b/headless-poc/local-preview/search.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <title>Search · OmniFlex local preview</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="of-shop"        content="REPLACE_WITH_YOUR.myshopify.com">
+  <meta name="of-token"       content="REPLACE_WITH_PUBLIC_STOREFRONT_TOKEN">
+  <meta name="of-api-version" content="2025-01">
+  <link rel="stylesheet" href="../omniflex-headless.css">
+  <link rel="stylesheet" href="./demo.css">
+  <script type="module" src="./config.local.js" onerror="void 0"></script>
+  <script type="module" src="../omniflex-headless.js"></script>
+</head>
+<body>
+  <div class="demo-banner">
+    Predictive search demo. Type 2+ characters to see live Storefront API results.
+  </div>
+
+  <header class="demo-header">
+    <a href="./index.html" class="demo-header__brand">OMNIFLEX</a>
+    <nav class="demo-nav">
+      <a href="./collection.html">Shop</a>
+      <a href="./product.html">Product</a>
+      <a href="./search.html">Search</a>
+    </nav>
+    <a href="#" class="demo-cart" data-of-cart-toggle>
+      Cart <span data-of-cart-count>0</span>
+    </a>
+  </header>
+
+  <main>
+    <h1>Search</h1>
+    <div data-of-search></div>
+  </main>
+</body>
+</html>

--- a/headless-poc/omniflex-headless.css
+++ b/headless-poc/omniflex-headless.css
@@ -74,6 +74,51 @@
 .of-collection__name { font-size: 1rem; margin: 0.5rem 0 0.25rem; }
 .of-collection__price { font-size: 0.875rem; opacity: 0.8; }
 
+.of-search { position: relative; width: 100%; max-width: 24rem; }
+.of-search__input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid currentColor;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+}
+.of-search__results {
+  position: absolute;
+  left: 0; right: 0; top: 100%;
+  background: #fff;
+  color: #111;
+  border: 1px solid #ddd;
+  border-top: 0;
+  max-height: 60vh;
+  overflow-y: auto;
+  z-index: 100;
+}
+.of-search__products,
+.of-search__queries { list-style: none; margin: 0; padding: 0; }
+.of-search__product a {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+  color: inherit;
+}
+.of-search__product a:hover { background: #f4f4f4; }
+.of-search__product img { width: 48px; height: 48px; object-fit: cover; }
+.of-search__product-title { font-size: 0.875rem; }
+.of-search__product-price { font-size: 0.875rem; opacity: 0.7; }
+.of-search__query a {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+  color: inherit;
+  border-top: 1px solid #eee;
+  font-size: 0.875rem;
+}
+.of-search__query a:hover { background: #f4f4f4; }
+
 .of-drawer {
   position: fixed; inset: 0;
   pointer-events: none;

--- a/headless-poc/omniflex-headless.css
+++ b/headless-poc/omniflex-headless.css
@@ -1,0 +1,143 @@
+/*
+ * OmniFlex headless — minimal default styles.
+ * Override anything in Webflow Designer; class names are namespaced `of-*`.
+ */
+
+.of-product {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 768px) {
+  .of-product { grid-template-columns: 1fr 1fr; }
+}
+.of-product__image { width: 100%; height: auto; display: block; }
+.of-product__title { font-size: 2rem; margin: 0 0 0.5rem; }
+.of-product__price { font-size: 1.25rem; margin-bottom: 1rem; }
+.of-product__option { margin-bottom: 1rem; }
+.of-product__option-label {
+  display: block;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+.of-product__option-values { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.of-product__option-value {
+  padding: 0.5rem 1rem;
+  border: 1px solid currentColor;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+.of-product__option-value[aria-pressed="true"] {
+  background: currentColor;
+  color: #fff;
+}
+.of-product__quantity { margin-bottom: 1rem; }
+.of-product__quantity input { width: 4rem; }
+.of-product__add {
+  width: 100%;
+  padding: 1rem;
+  border: 0;
+  background: #111;
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.of-product__add:disabled { opacity: 0.5; cursor: not-allowed; }
+.of-product__description { margin-top: 1.5rem; }
+
+.of-collection__grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+.of-collection__link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+.of-collection__image {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  display: block;
+}
+.of-collection__name { font-size: 1rem; margin: 0.5rem 0 0.25rem; }
+.of-collection__price { font-size: 0.875rem; opacity: 0.8; }
+
+.of-drawer {
+  position: fixed; inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+}
+.of-drawer[aria-hidden="false"] { pointer-events: auto; }
+.of-drawer__scrim {
+  position: absolute; inset: 0;
+  background: rgba(0,0,0,0.5);
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+.of-drawer[aria-hidden="false"] .of-drawer__scrim { opacity: 1; }
+.of-drawer__panel {
+  position: absolute; top: 0; right: 0; bottom: 0;
+  width: min(420px, 100%);
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 250ms ease;
+  box-shadow: -4px 0 24px rgba(0,0,0,0.15);
+}
+.of-drawer[aria-hidden="false"] .of-drawer__panel { transform: translateX(0); }
+.of-drawer__header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1rem; border-bottom: 1px solid #eee;
+}
+.of-drawer__close {
+  font-size: 1.5rem; line-height: 1;
+  background: transparent; border: 0; cursor: pointer;
+}
+.of-drawer__lines {
+  list-style: none; margin: 0; padding: 0;
+  flex: 1; overflow-y: auto;
+}
+.of-drawer__empty { padding: 2rem; text-align: center; opacity: 0.7; }
+.of-drawer__line {
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 1rem;
+  border-bottom: 1px solid #eee;
+}
+.of-drawer__line-image { width: 64px; height: 64px; object-fit: cover; }
+.of-drawer__line-title { font-weight: 600; }
+.of-drawer__line-variant { font-size: 0.875rem; opacity: 0.7; }
+.of-drawer__line-controls { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.5rem; }
+.of-drawer__line-qty { width: 3rem; }
+.of-drawer__line-remove {
+  background: transparent; border: 0; cursor: pointer;
+  font: inherit; text-decoration: underline; padding: 0;
+}
+.of-drawer__footer {
+  border-top: 1px solid #eee;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+.of-drawer__subtotal { font-weight: 600; }
+.of-drawer__checkout {
+  display: block; padding: 1rem; text-align: center;
+  background: #111; color: #fff; text-decoration: none;
+  font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+}
+.of-drawer__checkout:not([href]) { opacity: 0.5; pointer-events: none; }

--- a/headless-poc/omniflex-headless.js
+++ b/headless-poc/omniflex-headless.js
@@ -23,12 +23,26 @@ const cfg = (() => {
   const shop = get('of-shop');
   const token = get('of-token');
   const apiVersion = get('of-api-version') || '2025-01';
+  // Country/language for @inContext — drives presentment currency & translations.
+  // Resolution order: explicit <meta>, <html lang>, browser language, fallback.
+  const country =
+    get('of-country')?.toUpperCase() ||
+    document.documentElement.lang?.split('-')[1]?.toUpperCase() ||
+    new Intl.Locale(navigator.language || 'en-US').region ||
+    'US';
+  const language =
+    get('of-language')?.toUpperCase() ||
+    document.documentElement.lang?.split('-')[0]?.toUpperCase() ||
+    new Intl.Locale(navigator.language || 'en-US').language?.toUpperCase() ||
+    'EN';
   if (!shop || !token) {
     console.error('[omniflex] missing <meta name="of-shop"> or <meta name="of-token">');
   }
   return {
     shop,
     token,
+    country,
+    language,
     endpoint: `https://${shop}/api/${apiVersion}/graphql.json`,
   };
 })();
@@ -77,24 +91,30 @@ const PRODUCT_FIELDS = `
   }
 `;
 
-const Q_PRODUCT = `query Product($handle: String!) {
-  product(handle: $handle) { ${PRODUCT_FIELDS} }
-}`;
+// All product/collection queries take @inContext directives so prices and
+// availability are returned in the visitor's presentment currency. Cart
+// mutations also accept country/language and Shopify will create the cart
+// with the matching buyerIdentity.countryCode automatically.
+const Q_PRODUCT = `query Product($handle: String!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    product(handle: $handle) { ${PRODUCT_FIELDS} }
+  }`;
 
-const Q_COLLECTION = `query Collection($handle: String!, $first: Int!) {
-  collection(handle: $handle) {
-    id
-    title
-    description
-    products(first: $first) {
-      nodes {
-        id handle title
-        featuredImage { url altText }
-        priceRange { minVariantPrice { amount currencyCode } }
+const Q_COLLECTION = `query Collection($handle: String!, $first: Int!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    collection(handle: $handle) {
+      id
+      title
+      description
+      products(first: $first) {
+        nodes {
+          id handle title
+          featuredImage { url altText }
+          priceRange { minVariantPrice { amount currencyCode } }
+        }
       }
     }
-  }
-}`;
+  }`;
 
 const CART_FIELDS = `
   id
@@ -121,7 +141,12 @@ const CART_FIELDS = `
   }
 `;
 
-const M_CART_CREATE = `mutation { cartCreate { cart { ${CART_FIELDS} } userErrors { message } } }`;
+const M_CART_CREATE = `mutation($country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    cartCreate(input: { buyerIdentity: { countryCode: $country } }) {
+      cart { ${CART_FIELDS} } userErrors { message }
+    }
+  }`;
 
 const M_CART_LINES_ADD = `mutation($cartId: ID!, $lines: [CartLineInput!]!) {
   cartLinesAdd(cartId: $cartId, lines: $lines) {
@@ -178,7 +203,10 @@ async function ensureCart() {
   if (cartState) return cartState;
   const existing = await loadCart();
   if (existing) return existing;
-  const { cartCreate } = await gql(M_CART_CREATE);
+  const { cartCreate } = await gql(M_CART_CREATE, {
+    country: cfg.country,
+    language: cfg.language,
+  });
   const cart = cartCreate.cart;
   localStorage.setItem(CART_KEY, cart.id);
   cartState = cart;
@@ -352,6 +380,39 @@ function renderProduct(host, product) {
   updateForSelection();
 }
 
+function injectProductJsonLd(product) {
+  if (!product) return;
+  // Webflow does not SSR Shopify product data, so search engines will only
+  // see structured data if we inject it client-side. Googlebot reliably
+  // executes JS for JSON-LD; other crawlers vary. For tighter SEO, render
+  // these tags from a Cloudflare Worker that proxies the Webflow PDP.
+  const offers = product.variants.nodes.map((v) => ({
+    '@type': 'Offer',
+    sku: v.id,
+    price: v.price.amount,
+    priceCurrency: v.price.currencyCode,
+    availability: v.availableForSale
+      ? 'https://schema.org/InStock'
+      : 'https://schema.org/OutOfStock',
+    url: location.href,
+  }));
+  const ld = {
+    '@context': 'https://schema.org/',
+    '@type': 'Product',
+    name: product.title,
+    description: product.description,
+    image: product.images.nodes.map((i) => i.url),
+    sku: product.id,
+    offers: offers.length === 1 ? offers[0] : offers,
+  };
+  document.querySelectorAll('script[data-of-jsonld]').forEach((n) => n.remove());
+  const tag = document.createElement('script');
+  tag.type = 'application/ld+json';
+  tag.dataset.ofJsonld = 'product';
+  tag.textContent = JSON.stringify(ld);
+  document.head.appendChild(tag);
+}
+
 function renderCollection(host, collection) {
   if (!collection) {
     host.innerHTML = '<p class="of-empty">Collection not found.</p>';
@@ -510,7 +571,11 @@ async function mountAll() {
     }
     const handle = btn.dataset.ofHandle;
     if (!handle) return;
-    const { product } = await gql(Q_PRODUCT, { handle });
+    const { product } = await gql(Q_PRODUCT, {
+      handle,
+      country: cfg.country,
+      language: cfg.language,
+    });
     const firstAvailable = product?.variants.nodes.find((v) => v.availableForSale);
     if (firstAvailable) {
       await addLine(firstAvailable.id, 1);
@@ -522,8 +587,13 @@ async function mountAll() {
   for (const host of document.querySelectorAll('[data-of-product]')) {
     const handle = host.getAttribute('data-of-product');
     try {
-      const { product } = await gql(Q_PRODUCT, { handle });
+      const { product } = await gql(Q_PRODUCT, {
+        handle,
+        country: cfg.country,
+        language: cfg.language,
+      });
       renderProduct(host, product);
+      injectProductJsonLd(product);
     } catch (e) {
       console.error('[omniflex] PDP failed', handle, e);
     }
@@ -534,7 +604,12 @@ async function mountAll() {
     const handle = host.getAttribute('data-of-collection');
     const limit = parseInt(host.getAttribute('data-of-limit') || '24', 10);
     try {
-      const { collection } = await gql(Q_COLLECTION, { handle, first: limit });
+      const { collection } = await gql(Q_COLLECTION, {
+        handle,
+        first: limit,
+        country: cfg.country,
+        language: cfg.language,
+      });
       renderCollection(host, collection);
     } catch (e) {
       console.error('[omniflex] PLP failed', handle, e);

--- a/headless-poc/omniflex-headless.js
+++ b/headless-poc/omniflex-headless.js
@@ -1,0 +1,565 @@
+/**
+ * OmniFlex headless Webflow ↔ Shopify storefront client.
+ *
+ * Single-file ES module. Drop-in via <script type="module">.
+ * Reads config from <meta> tags in the host page:
+ *   <meta name="of-shop"        content="omniflexfitness.myshopify.com">
+ *   <meta name="of-token"       content="public-storefront-api-token">
+ *   <meta name="of-api-version" content="2025-01">
+ *
+ * Mounts on data-attributes the Webflow Designer can add to elements:
+ *   [data-of-product="<handle>"]      → render PDP into this element
+ *   [data-of-collection="<handle>"]   → render PLP grid into this element
+ *   [data-of-add-to-cart][data-of-handle][data-of-variant-id?]
+ *                                     → wire any button as add-to-cart
+ *   [data-of-cart-toggle]             → open the cart drawer
+ *   [data-of-cart-count]              → live line-item count badge
+ *
+ * No bundler. No framework. Vanilla ES2022.
+ */
+
+const cfg = (() => {
+  const get = (n) => document.querySelector(`meta[name="${n}"]`)?.content;
+  const shop = get('of-shop');
+  const token = get('of-token');
+  const apiVersion = get('of-api-version') || '2025-01';
+  if (!shop || !token) {
+    console.error('[omniflex] missing <meta name="of-shop"> or <meta name="of-token">');
+  }
+  return {
+    shop,
+    token,
+    endpoint: `https://${shop}/api/${apiVersion}/graphql.json`,
+  };
+})();
+
+// ---------------------------------------------------------------------------
+// Storefront API client
+// ---------------------------------------------------------------------------
+
+async function gql(query, variables = {}) {
+  const res = await fetch(cfg.endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Shopify-Storefront-Access-Token': cfg.token,
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`Storefront API ${res.status}`);
+  const json = await res.json();
+  if (json.errors) throw new Error(JSON.stringify(json.errors));
+  return json.data;
+}
+
+const PRODUCT_FIELDS = `
+  id
+  handle
+  title
+  description
+  descriptionHtml
+  featuredImage { url altText width height }
+  images(first: 10) { nodes { url altText width height } }
+  options { id name values }
+  priceRange { minVariantPrice { amount currencyCode } }
+  variants(first: 100) {
+    nodes {
+      id
+      title
+      availableForSale
+      quantityAvailable
+      price { amount currencyCode }
+      compareAtPrice { amount currencyCode }
+      selectedOptions { name value }
+      image { url altText }
+    }
+  }
+`;
+
+const Q_PRODUCT = `query Product($handle: String!) {
+  product(handle: $handle) { ${PRODUCT_FIELDS} }
+}`;
+
+const Q_COLLECTION = `query Collection($handle: String!, $first: Int!) {
+  collection(handle: $handle) {
+    id
+    title
+    description
+    products(first: $first) {
+      nodes {
+        id handle title
+        featuredImage { url altText }
+        priceRange { minVariantPrice { amount currencyCode } }
+      }
+    }
+  }
+}`;
+
+const CART_FIELDS = `
+  id
+  checkoutUrl
+  totalQuantity
+  cost {
+    subtotalAmount { amount currencyCode }
+    totalAmount { amount currencyCode }
+  }
+  lines(first: 100) {
+    nodes {
+      id
+      quantity
+      cost { totalAmount { amount currencyCode } }
+      merchandise {
+        ... on ProductVariant {
+          id title
+          image { url altText }
+          product { handle title }
+          selectedOptions { name value }
+        }
+      }
+    }
+  }
+`;
+
+const M_CART_CREATE = `mutation { cartCreate { cart { ${CART_FIELDS} } userErrors { message } } }`;
+
+const M_CART_LINES_ADD = `mutation($cartId: ID!, $lines: [CartLineInput!]!) {
+  cartLinesAdd(cartId: $cartId, lines: $lines) {
+    cart { ${CART_FIELDS} } userErrors { message }
+  }
+}`;
+
+const M_CART_LINES_UPDATE = `mutation($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
+  cartLinesUpdate(cartId: $cartId, lines: $lines) {
+    cart { ${CART_FIELDS} } userErrors { message }
+  }
+}`;
+
+const M_CART_LINES_REMOVE = `mutation($cartId: ID!, $lineIds: [ID!]!) {
+  cartLinesRemove(cartId: $cartId, lineIds: $lineIds) {
+    cart { ${CART_FIELDS} } userErrors { message }
+  }
+}`;
+
+const Q_CART = `query($id: ID!) { cart(id: $id) { ${CART_FIELDS} } }`;
+
+// ---------------------------------------------------------------------------
+// Cart manager (localStorage-backed)
+// ---------------------------------------------------------------------------
+
+const CART_KEY = 'of-cart-id';
+const cartListeners = new Set();
+
+let cartState = null;
+
+function emit() {
+  for (const fn of cartListeners) fn(cartState);
+}
+
+async function loadCart() {
+  const id = localStorage.getItem(CART_KEY);
+  if (!id) return null;
+  try {
+    const { cart } = await gql(Q_CART, { id });
+    if (!cart) {
+      localStorage.removeItem(CART_KEY);
+      return null;
+    }
+    cartState = cart;
+    emit();
+    return cart;
+  } catch (e) {
+    console.warn('[omniflex] failed to load cart', e);
+    return null;
+  }
+}
+
+async function ensureCart() {
+  if (cartState) return cartState;
+  const existing = await loadCart();
+  if (existing) return existing;
+  const { cartCreate } = await gql(M_CART_CREATE);
+  const cart = cartCreate.cart;
+  localStorage.setItem(CART_KEY, cart.id);
+  cartState = cart;
+  emit();
+  return cart;
+}
+
+async function addLine(variantId, quantity = 1) {
+  const cart = await ensureCart();
+  const { cartLinesAdd } = await gql(M_CART_LINES_ADD, {
+    cartId: cart.id,
+    lines: [{ merchandiseId: variantId, quantity }],
+  });
+  if (cartLinesAdd.userErrors.length) {
+    throw new Error(cartLinesAdd.userErrors.map((e) => e.message).join('; '));
+  }
+  cartState = cartLinesAdd.cart;
+  emit();
+  return cartState;
+}
+
+async function updateLine(lineId, quantity) {
+  const cart = await ensureCart();
+  const { cartLinesUpdate } = await gql(M_CART_LINES_UPDATE, {
+    cartId: cart.id,
+    lines: [{ id: lineId, quantity }],
+  });
+  cartState = cartLinesUpdate.cart;
+  emit();
+  return cartState;
+}
+
+async function removeLine(lineId) {
+  const cart = await ensureCart();
+  const { cartLinesRemove } = await gql(M_CART_LINES_REMOVE, {
+    cartId: cart.id,
+    lineIds: [lineId],
+  });
+  cartState = cartLinesRemove.cart;
+  emit();
+  return cartState;
+}
+
+function onCartChange(fn) {
+  cartListeners.add(fn);
+  if (cartState) fn(cartState);
+  return () => cartListeners.delete(fn);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function money(m) {
+  if (!m) return '';
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: m.currencyCode,
+  }).format(parseFloat(m.amount));
+}
+
+function findVariant(product, selected) {
+  return product.variants.nodes.find((v) =>
+    v.selectedOptions.every((o) => selected[o.name] === o.value),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Renderers — intentionally minimal markup so Webflow CSS can override
+// ---------------------------------------------------------------------------
+
+function renderProduct(host, product) {
+  if (!product) {
+    host.innerHTML = '<p class="of-empty">Product not found.</p>';
+    return;
+  }
+  const initialSelected = Object.fromEntries(
+    product.options.map((o) => [o.name, o.values[0]]),
+  );
+  let selected = { ...initialSelected };
+
+  host.classList.add('of-product');
+  host.innerHTML = `
+    <div class="of-product__media">
+      <img class="of-product__image"
+        src="${product.featuredImage?.url ?? ''}"
+        alt="${product.featuredImage?.altText ?? product.title}">
+    </div>
+    <div class="of-product__info">
+      <h1 class="of-product__title">${product.title}</h1>
+      <div class="of-product__price" data-of-price></div>
+      <div class="of-product__options"></div>
+      <div class="of-product__quantity">
+        <label>Qty <input type="number" min="1" value="1" data-of-qty></label>
+      </div>
+      <button class="of-product__add" data-of-add disabled>Add to cart</button>
+      <div class="of-product__description">${product.descriptionHtml ?? ''}</div>
+    </div>
+  `;
+
+  const optionsRoot = host.querySelector('.of-product__options');
+  for (const opt of product.options) {
+    const wrap = document.createElement('div');
+    wrap.className = 'of-product__option';
+    wrap.innerHTML = `<span class="of-product__option-label">${opt.name}</span>`;
+    const group = document.createElement('div');
+    group.className = 'of-product__option-values';
+    for (const value of opt.values) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'of-product__option-value';
+      btn.textContent = value;
+      btn.dataset.optionName = opt.name;
+      btn.dataset.optionValue = value;
+      if (selected[opt.name] === value) btn.setAttribute('aria-pressed', 'true');
+      btn.addEventListener('click', () => {
+        selected[opt.name] = value;
+        for (const sib of group.children) {
+          sib.setAttribute(
+            'aria-pressed',
+            sib.dataset.optionValue === value ? 'true' : 'false',
+          );
+        }
+        updateForSelection();
+      });
+      group.appendChild(btn);
+    }
+    wrap.appendChild(group);
+    optionsRoot.appendChild(wrap);
+  }
+
+  const priceEl = host.querySelector('[data-of-price]');
+  const addBtn = host.querySelector('[data-of-add]');
+  const qtyInput = host.querySelector('[data-of-qty]');
+
+  function updateForSelection() {
+    const variant = findVariant(product, selected);
+    if (!variant) {
+      priceEl.textContent = 'Unavailable';
+      addBtn.disabled = true;
+      addBtn.dataset.variantId = '';
+      return;
+    }
+    priceEl.textContent = money(variant.price);
+    addBtn.disabled = !variant.availableForSale;
+    addBtn.dataset.variantId = variant.id;
+    addBtn.textContent = variant.availableForSale ? 'Add to cart' : 'Sold out';
+  }
+
+  addBtn.addEventListener('click', async () => {
+    const id = addBtn.dataset.variantId;
+    if (!id) return;
+    addBtn.disabled = true;
+    const prev = addBtn.textContent;
+    addBtn.textContent = 'Adding…';
+    try {
+      await addLine(id, parseInt(qtyInput.value || '1', 10));
+      addBtn.textContent = 'Added ✓';
+      openDrawer();
+      setTimeout(() => {
+        addBtn.textContent = prev;
+        addBtn.disabled = false;
+      }, 1200);
+    } catch (e) {
+      console.error(e);
+      addBtn.textContent = 'Error — retry';
+      addBtn.disabled = false;
+    }
+  });
+
+  updateForSelection();
+}
+
+function renderCollection(host, collection) {
+  if (!collection) {
+    host.innerHTML = '<p class="of-empty">Collection not found.</p>';
+    return;
+  }
+  host.classList.add('of-collection');
+  host.innerHTML = `
+    <header class="of-collection__header">
+      <h1 class="of-collection__title">${collection.title}</h1>
+    </header>
+    <ul class="of-collection__grid">
+      ${collection.products.nodes
+        .map(
+          (p) => `
+        <li class="of-collection__card">
+          <a class="of-collection__link" href="/product/${p.handle}">
+            <img class="of-collection__image"
+              src="${p.featuredImage?.url ?? ''}"
+              alt="${p.featuredImage?.altText ?? p.title}">
+            <h2 class="of-collection__name">${p.title}</h2>
+            <div class="of-collection__price">${money(p.priceRange.minVariantPrice)}</div>
+          </a>
+        </li>`,
+        )
+        .join('')}
+    </ul>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Cart drawer (DOM injected once, site-wide)
+// ---------------------------------------------------------------------------
+
+let drawerEl;
+
+function ensureDrawer() {
+  if (drawerEl) return drawerEl;
+  drawerEl = document.createElement('aside');
+  drawerEl.className = 'of-drawer';
+  drawerEl.setAttribute('aria-hidden', 'true');
+  drawerEl.innerHTML = `
+    <div class="of-drawer__scrim" data-of-drawer-close></div>
+    <div class="of-drawer__panel" role="dialog" aria-label="Shopping cart">
+      <header class="of-drawer__header">
+        <h2>Your cart</h2>
+        <button class="of-drawer__close" data-of-drawer-close aria-label="Close">×</button>
+      </header>
+      <ul class="of-drawer__lines" data-of-drawer-lines></ul>
+      <footer class="of-drawer__footer">
+        <div class="of-drawer__subtotal" data-of-drawer-subtotal></div>
+        <a class="of-drawer__checkout" data-of-drawer-checkout href="#">Checkout</a>
+      </footer>
+    </div>
+  `;
+  document.body.appendChild(drawerEl);
+  drawerEl.addEventListener('click', (e) => {
+    const t = e.target;
+    if (!(t instanceof Element)) return;
+    if (t.matches('[data-of-drawer-close]')) closeDrawer();
+    const removeBtn = t.closest('[data-of-line-remove]');
+    if (removeBtn) {
+      removeLine(removeBtn.dataset.lineId).catch(console.error);
+    }
+  });
+  drawerEl.addEventListener('change', (e) => {
+    const t = e.target;
+    if (!(t instanceof HTMLInputElement)) return;
+    if (t.matches('[data-of-line-qty]')) {
+      const q = Math.max(0, parseInt(t.value || '0', 10));
+      updateLine(t.dataset.lineId, q).catch(console.error);
+    }
+  });
+  return drawerEl;
+}
+
+function openDrawer() {
+  ensureDrawer().setAttribute('aria-hidden', 'false');
+}
+function closeDrawer() {
+  ensureDrawer().setAttribute('aria-hidden', 'true');
+}
+
+function paintDrawer(cart) {
+  const root = ensureDrawer();
+  const lines = root.querySelector('[data-of-drawer-lines]');
+  const subtotal = root.querySelector('[data-of-drawer-subtotal]');
+  const checkout = root.querySelector('[data-of-drawer-checkout]');
+  if (!cart || cart.lines.nodes.length === 0) {
+    lines.innerHTML = '<li class="of-drawer__empty">Your cart is empty.</li>';
+    subtotal.textContent = '';
+    checkout.removeAttribute('href');
+    return;
+  }
+  lines.innerHTML = cart.lines.nodes
+    .map((l) => {
+      const v = l.merchandise;
+      return `
+      <li class="of-drawer__line">
+        <img src="${v.image?.url ?? ''}" alt="${v.image?.altText ?? ''}" class="of-drawer__line-image">
+        <div class="of-drawer__line-body">
+          <div class="of-drawer__line-title">${v.product.title}</div>
+          <div class="of-drawer__line-variant">${v.title === 'Default Title' ? '' : v.title}</div>
+          <div class="of-drawer__line-controls">
+            <input type="number" min="0" value="${l.quantity}"
+              data-of-line-qty data-line-id="${l.id}" class="of-drawer__line-qty">
+            <button data-of-line-remove data-line-id="${l.id}" class="of-drawer__line-remove">Remove</button>
+          </div>
+        </div>
+        <div class="of-drawer__line-price">${money(l.cost.totalAmount)}</div>
+      </li>`;
+    })
+    .join('');
+  subtotal.textContent = `Subtotal: ${money(cart.cost.subtotalAmount)}`;
+  checkout.setAttribute('href', cart.checkoutUrl);
+}
+
+// ---------------------------------------------------------------------------
+// Auto-mount
+// ---------------------------------------------------------------------------
+
+async function mountAll() {
+  // Cart count badges
+  const updateCounts = (cart) => {
+    const n = cart?.totalQuantity ?? 0;
+    for (const el of document.querySelectorAll('[data-of-cart-count]')) {
+      el.textContent = String(n);
+    }
+  };
+  onCartChange((c) => {
+    updateCounts(c);
+    paintDrawer(c);
+  });
+
+  // Cart toggles
+  for (const el of document.querySelectorAll('[data-of-cart-toggle]')) {
+    el.addEventListener('click', (e) => {
+      e.preventDefault();
+      openDrawer();
+    });
+  }
+
+  // Generic add-to-cart buttons (used inside Webflow CMS-templated grids)
+  document.addEventListener('click', async (e) => {
+    const btn = e.target.closest?.('[data-of-add-to-cart]');
+    if (!btn) return;
+    e.preventDefault();
+    const variantId = btn.dataset.ofVariantId;
+    if (variantId) {
+      try {
+        await addLine(variantId, 1);
+        openDrawer();
+      } catch (err) {
+        console.error(err);
+      }
+      return;
+    }
+    const handle = btn.dataset.ofHandle;
+    if (!handle) return;
+    const { product } = await gql(Q_PRODUCT, { handle });
+    const firstAvailable = product?.variants.nodes.find((v) => v.availableForSale);
+    if (firstAvailable) {
+      await addLine(firstAvailable.id, 1);
+      openDrawer();
+    }
+  });
+
+  // PDP mounts
+  for (const host of document.querySelectorAll('[data-of-product]')) {
+    const handle = host.getAttribute('data-of-product');
+    try {
+      const { product } = await gql(Q_PRODUCT, { handle });
+      renderProduct(host, product);
+    } catch (e) {
+      console.error('[omniflex] PDP failed', handle, e);
+    }
+  }
+
+  // PLP mounts
+  for (const host of document.querySelectorAll('[data-of-collection]')) {
+    const handle = host.getAttribute('data-of-collection');
+    const limit = parseInt(host.getAttribute('data-of-limit') || '24', 10);
+    try {
+      const { collection } = await gql(Q_COLLECTION, { handle, first: limit });
+      renderCollection(host, collection);
+    } catch (e) {
+      console.error('[omniflex] PLP failed', handle, e);
+    }
+  }
+
+  // Hydrate cart on first paint so badges reflect persisted state
+  await loadCart().catch(console.warn);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', mountAll);
+} else {
+  mountAll();
+}
+
+// Public API for ad-hoc use from page-level Webflow scripts
+window.OmniFlex = {
+  addLine,
+  updateLine,
+  removeLine,
+  ensureCart,
+  loadCart,
+  onCartChange,
+  openDrawer,
+  closeDrawer,
+  gql,
+};

--- a/headless-poc/omniflex-headless.js
+++ b/headless-poc/omniflex-headless.js
@@ -116,6 +116,19 @@ const Q_COLLECTION = `query Collection($handle: String!, $first: Int!, $country:
     }
   }`;
 
+const Q_PREDICTIVE_SEARCH = `query Predict($q: String!, $country: CountryCode, $language: LanguageCode)
+  @inContext(country: $country, language: $language) {
+    predictiveSearch(query: $q, limit: 8, types: [PRODUCT, COLLECTION, QUERY]) {
+      products {
+        id handle title
+        featuredImage { url altText }
+        priceRange { minVariantPrice { amount currencyCode } }
+      }
+      collections { id handle title }
+      queries { text styledText }
+    }
+  }`;
+
 const CART_FIELDS = `
   id
   checkoutUrl
@@ -380,6 +393,69 @@ function renderProduct(host, product) {
   updateForSelection();
 }
 
+function debounce(fn, ms) {
+  let t;
+  return (...args) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...args), ms);
+  };
+}
+
+function mountSearch(host) {
+  host.classList.add('of-search');
+  host.innerHTML = `
+    <input type="search" class="of-search__input"
+      placeholder="Search products…" autocomplete="off"
+      aria-label="Search">
+    <div class="of-search__results" hidden>
+      <ul class="of-search__products"></ul>
+      <ul class="of-search__queries"></ul>
+    </div>
+  `;
+  const input = host.querySelector('.of-search__input');
+  const panel = host.querySelector('.of-search__results');
+  const productsUl = host.querySelector('.of-search__products');
+  const queriesUl = host.querySelector('.of-search__queries');
+
+  const run = debounce(async (q) => {
+    if (!q || q.length < 2) {
+      panel.hidden = true;
+      return;
+    }
+    try {
+      const { predictiveSearch } = await gql(Q_PREDICTIVE_SEARCH, {
+        q,
+        country: cfg.country,
+        language: cfg.language,
+      });
+      productsUl.innerHTML = predictiveSearch.products.map((p) => `
+        <li class="of-search__product">
+          <a href="/product/${p.handle}">
+            <img src="${p.featuredImage?.url ?? ''}" alt="${p.featuredImage?.altText ?? ''}">
+            <span class="of-search__product-title">${p.title}</span>
+            <span class="of-search__product-price">${money(p.priceRange.minVariantPrice)}</span>
+          </a>
+        </li>`).join('');
+      queriesUl.innerHTML = predictiveSearch.queries.map((q) =>
+        `<li class="of-search__query"><a href="/search?q=${encodeURIComponent(q.text)}">${q.styledText ?? q.text}</a></li>`
+      ).join('');
+      panel.hidden =
+        predictiveSearch.products.length === 0 &&
+        predictiveSearch.queries.length === 0;
+    } catch (e) {
+      console.error('[omniflex] search failed', e);
+    }
+  }, 200);
+
+  input.addEventListener('input', (e) => run(e.target.value.trim()));
+  input.addEventListener('focus', () => {
+    if (input.value.trim().length >= 2) panel.hidden = false;
+  });
+  document.addEventListener('click', (e) => {
+    if (!host.contains(e.target)) panel.hidden = true;
+  });
+}
+
 function injectProductJsonLd(product) {
   if (!product) return;
   // Webflow does not SSR Shopify product data, so search engines will only
@@ -597,6 +673,11 @@ async function mountAll() {
     } catch (e) {
       console.error('[omniflex] PDP failed', handle, e);
     }
+  }
+
+  // Search mounts
+  for (const host of document.querySelectorAll('[data-of-search]')) {
+    mountSearch(host);
   }
 
   // PLP mounts

--- a/headless-poc/omniflex-headless.js
+++ b/headless-poc/omniflex-headless.js
@@ -430,7 +430,7 @@ function mountSearch(host) {
       });
       productsUl.innerHTML = predictiveSearch.products.map((p) => `
         <li class="of-search__product">
-          <a href="/product/${p.handle}">
+          <a href="/products/${p.handle}">
             <img src="${p.featuredImage?.url ?? ''}" alt="${p.featuredImage?.altText ?? ''}">
             <span class="of-search__product-title">${p.title}</span>
             <span class="of-search__product-price">${money(p.priceRange.minVariantPrice)}</span>
@@ -504,7 +504,7 @@ function renderCollection(host, collection) {
         .map(
           (p) => `
         <li class="of-collection__card">
-          <a class="of-collection__link" href="/product/${p.handle}">
+          <a class="of-collection__link" href="/products/${p.handle}">
             <img class="of-collection__image"
               src="${p.featuredImage?.url ?? ''}"
               alt="${p.featuredImage?.altText ?? p.title}">

--- a/headless-poc/repo-strategy.md
+++ b/headless-poc/repo-strategy.md
@@ -1,0 +1,80 @@
+# Repo strategy: same repo or new repo for the Webflow frontend?
+
+**Recommendation: a new, independent repo for the headless frontend.** Keep the PoC here while you evaluate, but split before any production traffic. This document explains why, what the new repo should look like, and how to migrate.
+
+## The decisive reasons
+
+### 1. This repo is being auto-written by the Shopify CLI
+
+`git log --oneline` shows commits like `Update from Shopify for theme OmniFlex-Shopify-Theme/main` arriving regularly. That's the Shopify theme editor pushing changes back. **For a Liquid theme this is fine** — those files only affect Shopify rendering. **For a headless frontend it is dangerous** — every commit on `main` can move a jsDelivr-pinned tag silently, which means a non-engineer making a copy edit in the Shopify theme editor could change the live behavior of the Webflow storefront.
+
+This alone justifies the split. Even if you pin to commit SHAs (which you should), an automated process committing to the same repo as your storefront source is a footgun.
+
+### 2. Different deploy surfaces, different tooling
+
+| Surface | Tool | Lives where |
+|---|---|---|
+| Liquid theme | Shopify CLI (`shopify theme push`) | This repo |
+| Headless client JS | jsDelivr or a CDN, pinned to a commit | New repo |
+| Sync worker | Wrangler (`wrangler deploy`) | New repo |
+| Customer Account module | jsDelivr or a CDN | New repo |
+| E2E tests | Playwright in CI | New repo |
+
+The Shopify theme repo's CI surface is "validate Liquid + push to Shopify." The headless repo's is "type-check, build, run Playwright, deploy worker, publish CDN bundle." Mixing them means CI workflows constantly skip large parts of the repo and the failure surfaces are harder to reason about.
+
+### 3. Different contributors, different access controls
+
+Theme operators need Shopify admin and don't usually need GitHub Actions secrets. Headless engineers need Cloudflare account access, Webflow API tokens, and the ability to rotate Storefront tokens, but don't need Shopify admin. Putting the two roles in the same repo means giving everyone access to everything by default.
+
+### 4. Different lifecycle, different risk profile
+
+Once the Webflow rebuild ships, the Shopify theme stops getting marketing-page work — it becomes commerce-only and changes infrequently. The headless frontend becomes the high-velocity surface. Keeping them in one repo encourages cross-coupled commits and makes it harder to ship one without ceremonially deploying the other.
+
+## When *would* a single repo make sense?
+
+Only in narrow cases:
+- The same one or two engineers maintain both surfaces and there are no designers or marketers committing
+- The headless code is a thin shim (e.g. just a Buy Button SDK install) with no sync layer or worker
+- There is no jsDelivr pinning in play because the script is hosted on a private CDN you control and the repo is just a build source
+
+None of those describe OmniFlex's situation.
+
+## Proposed structure of the new repo
+
+```
+omniflex-storefront-headless/
+├── packages/
+│   ├── client/           # was headless-poc/omniflex-headless.{js,css}
+│   │   ├── src/
+│   │   ├── dist/         # bundled, minified, sourcemapped
+│   │   └── package.json  # esbuild build, publishes to npm or just tag releases
+│   ├── customer-account/ # was headless-poc/customer-account/
+│   ├── sync-worker/      # was headless-poc/sync/worker/
+│   └── sync-poll/        # was headless-poc/sync/sync.mjs (CI reconciliation)
+├── apps/
+│   └── webflow-embeds/   # raw HTML snippets the Designer pastes
+├── tests/                # was headless-poc/tests/
+├── .github/workflows/
+│   ├── ci.yml            # type-check + tests on PR
+│   ├── release.yml       # tag a SHA, publish bundle to CDN, deploy worker
+│   └── e2e-staging.yml   # Playwright vs. staging on push to main
+├── README.md
+└── pnpm-workspace.yaml
+```
+
+A monorepo (pnpm or npm workspaces) lets `client`, `customer-account`, and `sync-worker` share types and lint config without each becoming its own repo. Two repos minimum (this Shopify theme + the headless monorepo) is the right balance.
+
+## How to migrate (when you're ready)
+
+1. Stand up `omniflex-storefront-headless` as a new GitHub repo
+2. `git subtree split --prefix=headless-poc -b export-headless` from this repo, push to the new repo's `main`
+3. In the new repo, restructure into the package layout above
+4. Add `release.yml` that publishes a bundle to a private CDN (Cloudflare R2 + Workers route is the natural fit) and pins versions
+5. Update `headless-poc/webflow-embeds/site-wide-head.html` here to a temporary deprecation notice that points at the new repo's release tag URL
+6. Delete `headless-poc/` from this repo in a follow-up commit. Keep the `docs/webflow-integration-investigation.md` here as the historical record.
+
+Do this **once a real Webflow staging site is wired up** and the smoke tests pass — not before. Splitting empty scaffolds across two repos creates more setup work without payoff.
+
+## Until then
+
+Keep the PoC in `headless-poc/` on this branch. It's the right home for the evaluation phase. The split has a real cost (two CIs, two deploy keys, cross-repo issue tracking) and that cost is only worth paying once the architecture has earned it.

--- a/headless-poc/sync/.env.example
+++ b/headless-poc/sync/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env and fill in. Never commit .env.
+
+SHOPIFY_STORE=omniflexfitness.myshopify.com
+SHOPIFY_ADMIN_TOKEN=shpat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SHOPIFY_API_VERSION=2025-01
+
+WEBFLOW_TOKEN=wf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+WEBFLOW_COLLECTION_ID=000000000000000000000000
+# Optional. Required if you want sync to publish items live (not just save as draft).
+WEBFLOW_SITE_ID=000000000000000000000000

--- a/headless-poc/sync/.gitignore
+++ b/headless-poc/sync/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/headless-poc/sync/package.json
+++ b/headless-poc/sync/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "omniflex-shopify-webflow-sync",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "sync": "node sync.mjs",
+    "sync:dry": "node sync.mjs --dry",
+    "sync:watch": "node sync.mjs --watch 5"
+  }
+}

--- a/headless-poc/sync/sync.mjs
+++ b/headless-poc/sync/sync.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * Shopify → Webflow CMS one-way sync.
+ *
+ * Required env:
+ *   SHOPIFY_STORE              "omniflexfitness.myshopify.com"
+ *   SHOPIFY_ADMIN_TOKEN        Admin API access token (read_products)
+ *   SHOPIFY_API_VERSION        defaults to 2025-01
+ *   WEBFLOW_TOKEN              Webflow site API token
+ *   WEBFLOW_COLLECTION_ID      Target Webflow CMS collection ID
+ *   WEBFLOW_SITE_ID            (optional) for publish
+ *
+ * Run modes:
+ *   node sync.mjs               # one-shot sync
+ *   node sync.mjs --watch 5     # poll every 5 minutes
+ *   node sync.mjs --dry         # log changes without writing
+ *
+ * The Webflow CMS collection must include these slug-keyed fields:
+ *   name              (PlainText, required)
+ *   slug              (PlainText, required)
+ *   shopify-id        (PlainText)         — primary key for upsert
+ *   description       (RichText)
+ *   price             (Number)
+ *   currency          (PlainText)
+ *   featured-image    (Image)
+ *   in-stock          (Switch)
+ *   handle            (PlainText)
+ */
+
+const env = (k, fallback) => {
+  const v = process.env[k];
+  if (v === undefined && fallback === undefined) {
+    console.error(`missing env ${k}`);
+    process.exit(1);
+  }
+  return v ?? fallback;
+};
+
+const SHOPIFY_STORE = env('SHOPIFY_STORE');
+const SHOPIFY_ADMIN_TOKEN = env('SHOPIFY_ADMIN_TOKEN');
+const SHOPIFY_API_VERSION = env('SHOPIFY_API_VERSION', '2025-01');
+const WEBFLOW_TOKEN = env('WEBFLOW_TOKEN');
+const WEBFLOW_COLLECTION_ID = env('WEBFLOW_COLLECTION_ID');
+const WEBFLOW_SITE_ID = process.env.WEBFLOW_SITE_ID;
+
+const argv = process.argv.slice(2);
+const DRY = argv.includes('--dry');
+const watchIdx = argv.indexOf('--watch');
+const WATCH_MIN = watchIdx >= 0 ? parseInt(argv[watchIdx + 1] || '10', 10) : 0;
+
+const SHOPIFY_GQL = `https://${SHOPIFY_STORE}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
+const WEBFLOW_API = 'https://api.webflow.com/v2';
+
+// --------------------------------------------------------------------------
+// Shopify Admin API
+// --------------------------------------------------------------------------
+
+async function shopifyGql(query, variables) {
+  const res = await fetch(SHOPIFY_GQL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Shopify-Access-Token': SHOPIFY_ADMIN_TOKEN,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`shopify ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  if (json.errors) throw new Error(JSON.stringify(json.errors));
+  return json.data;
+}
+
+const Q_PRODUCTS = `
+  query Products($cursor: String) {
+    products(first: 50, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        handle
+        title
+        descriptionHtml
+        totalInventory
+        featuredImage { url altText }
+        priceRangeV2 { minVariantPrice { amount currencyCode } }
+      }
+    }
+  }
+`;
+
+async function* allShopifyProducts() {
+  let cursor = null;
+  while (true) {
+    const { products } = await shopifyGql(Q_PRODUCTS, { cursor });
+    for (const p of products.nodes) yield p;
+    if (!products.pageInfo.hasNextPage) break;
+    cursor = products.pageInfo.endCursor;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Webflow CMS API v2
+// --------------------------------------------------------------------------
+
+async function webflow(path, init = {}) {
+  const res = await fetch(`${WEBFLOW_API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${WEBFLOW_TOKEN}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...init.headers,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`webflow ${init.method || 'GET'} ${path} → ${res.status}: ${await res.text()}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+async function listAllWebflowItems() {
+  const items = [];
+  let offset = 0;
+  const limit = 100;
+  while (true) {
+    const data = await webflow(
+      `/collections/${WEBFLOW_COLLECTION_ID}/items?limit=${limit}&offset=${offset}`,
+    );
+    items.push(...(data.items ?? []));
+    offset += limit;
+    if (offset >= (data.pagination?.total ?? items.length)) break;
+  }
+  return items;
+}
+
+function shopifyToWebflow(p) {
+  return {
+    fieldData: {
+      name: p.title,
+      slug: p.handle,
+      'shopify-id': p.id,
+      handle: p.handle,
+      description: p.descriptionHtml ?? '',
+      price: p.priceRangeV2?.minVariantPrice
+        ? parseFloat(p.priceRangeV2.minVariantPrice.amount)
+        : null,
+      currency: p.priceRangeV2?.minVariantPrice?.currencyCode ?? null,
+      'featured-image': p.featuredImage?.url
+        ? { url: p.featuredImage.url, alt: p.featuredImage.altText ?? p.title }
+        : null,
+      'in-stock': (p.totalInventory ?? 0) > 0,
+    },
+  };
+}
+
+async function createItem(body) {
+  return webflow(`/collections/${WEBFLOW_COLLECTION_ID}/items`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function updateItem(itemId, body) {
+  return webflow(`/collections/${WEBFLOW_COLLECTION_ID}/items/${itemId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+async function deleteItem(itemId) {
+  return webflow(`/collections/${WEBFLOW_COLLECTION_ID}/items/${itemId}`, {
+    method: 'DELETE',
+  });
+}
+
+async function publishItems(itemIds) {
+  if (!WEBFLOW_SITE_ID || itemIds.length === 0) return;
+  return webflow(`/collections/${WEBFLOW_COLLECTION_ID}/items/publish`, {
+    method: 'POST',
+    body: JSON.stringify({ itemIds }),
+  });
+}
+
+// --------------------------------------------------------------------------
+// Sync
+// --------------------------------------------------------------------------
+
+async function syncOnce() {
+  console.log(`[sync] start ${new Date().toISOString()}${DRY ? ' (dry run)' : ''}`);
+
+  const existing = await listAllWebflowItems();
+  const byShopifyId = new Map();
+  for (const item of existing) {
+    const sid = item.fieldData?.['shopify-id'];
+    if (sid) byShopifyId.set(sid, item);
+  }
+  console.log(`[sync] webflow items: ${existing.length}`);
+
+  const seen = new Set();
+  let created = 0;
+  let updated = 0;
+  const touched = [];
+
+  for await (const p of allShopifyProducts()) {
+    seen.add(p.id);
+    const payload = shopifyToWebflow(p);
+    const current = byShopifyId.get(p.id);
+    if (!current) {
+      console.log(`[sync] +create ${p.handle}`);
+      if (!DRY) {
+        const item = await createItem(payload);
+        touched.push(item.id);
+      }
+      created++;
+    } else {
+      const stale = JSON.stringify(current.fieldData) !== JSON.stringify({ ...current.fieldData, ...payload.fieldData });
+      if (stale) {
+        console.log(`[sync] ~update ${p.handle}`);
+        if (!DRY) {
+          await updateItem(current.id, payload);
+          touched.push(current.id);
+        }
+        updated++;
+      }
+    }
+  }
+
+  let removed = 0;
+  for (const [sid, item] of byShopifyId) {
+    if (!seen.has(sid)) {
+      console.log(`[sync] -delete ${item.fieldData?.slug ?? item.id}`);
+      if (!DRY) await deleteItem(item.id);
+      removed++;
+    }
+  }
+
+  if (!DRY && touched.length > 0 && WEBFLOW_SITE_ID) {
+    console.log(`[sync] publishing ${touched.length} item(s)`);
+    await publishItems(touched);
+  }
+
+  console.log(`[sync] done — created=${created} updated=${updated} removed=${removed}`);
+}
+
+if (WATCH_MIN > 0) {
+  console.log(`[sync] watch mode every ${WATCH_MIN}m`);
+  await syncOnce();
+  setInterval(() => {
+    syncOnce().catch((e) => console.error('[sync] error', e));
+  }, WATCH_MIN * 60 * 1000);
+} else {
+  await syncOnce();
+}

--- a/headless-poc/sync/worker/README.md
+++ b/headless-poc/sync/worker/README.md
@@ -1,0 +1,66 @@
+# Webhook-driven sync (Cloudflare Worker)
+
+Replaces the polling `sync.mjs` with near-real-time updates. Shopify fires a webhook on every relevant product/inventory change; the Worker validates the HMAC and upserts a single item to Webflow CMS.
+
+## Why a Worker
+
+- **Free for typical traffic** (100K requests/day on the Workers free tier — far above webhook volume for any single store)
+- **No always-on infra** — replaces a Render/Railway cron worker
+- **Sub-100ms HMAC verification + ack**, with the actual Webflow write running in `ctx.waitUntil` so Shopify never sees latency from the slower side of the integration
+
+## Deploy
+
+```bash
+cd headless-poc/sync/worker
+npm install -g wrangler          # one-time
+wrangler login
+
+# Set vars in wrangler.toml (collection ID, store, site ID)
+# Then push secrets:
+wrangler secret put SHOPIFY_WEBHOOK_SECRET   # see step 2 below
+wrangler secret put SHOPIFY_ADMIN_TOKEN      # same Admin token as the polling sync
+wrangler secret put WEBFLOW_TOKEN
+
+wrangler deploy
+```
+
+The Worker prints its public URL on first deploy, e.g. `https://omniflex-shopify-webhook-sync.<account>.workers.dev`.
+
+## Register webhooks in Shopify
+
+Shopify admin → **Settings** → **Notifications** → **Webhooks** → **Create webhook** for each topic, all pointing at distinct paths on the Worker URL:
+
+| Topic | Path | Format |
+|---|---|---|
+| `Product creation` | `/webhooks/products/create` | JSON |
+| `Product update` | `/webhooks/products/update` | JSON |
+| `Product deletion` | `/webhooks/products/delete` | JSON |
+| `Inventory level update` | `/webhooks/inventory_levels/update` | JSON |
+
+Shopify will display a single "webhook signing secret" at the top of the page after the first webhook is created. Copy that value into `wrangler secret put SHOPIFY_WEBHOOK_SECRET` — the Worker uses it to verify HMAC on every request.
+
+## What gets synced
+
+Each topic maps to a single Webflow CMS write:
+
+- `products/create` & `products/update` → **PATCH or POST** the matching CMS item by `shopify-id`
+- `products/delete` → **DELETE** the matching item
+- `inventory_levels/update` → look up the variant's product via Admin API, then upsert (this is the only topic that requires a round trip to Shopify, because inventory webhooks deliver `inventory_item_id`, not `product_id`)
+
+## Idempotency and replay safety
+
+- All upserts key on `shopify-id` (the Shopify GID), so duplicate webhook deliveries are no-ops.
+- HMAC verification rejects replay attacks across stores. Replays *of the same webhook* from Shopify are intentional and harmless.
+- The Worker returns 200 immediately after HMAC verification; the actual Webflow API call runs in `waitUntil`. If Webflow is down, Shopify will not retry — accept this trade for fast acks. For stricter durability, replace `waitUntil` with a Queue producer and a consumer Worker.
+
+## Coexistence with the polling script
+
+Both can run simultaneously without conflict (the upsert is idempotent on `shopify-id`). Recommend keeping `sync.mjs --dry` in CI as a periodic reconciliation check — if it finds drift, the webhook delivery missed something.
+
+## Tearing it down
+
+```bash
+wrangler delete
+```
+
+Then disable the corresponding webhooks in Shopify admin.

--- a/headless-poc/sync/worker/worker.mjs
+++ b/headless-poc/sync/worker/worker.mjs
@@ -1,0 +1,241 @@
+/**
+ * Cloudflare Worker — Shopify webhooks → Webflow CMS upsert.
+ *
+ * Replaces the polling sync.mjs with near-real-time updates.
+ *
+ * Shopify webhook routing (configure in Shopify admin):
+ *   POST /webhooks/products/create        → products/create
+ *   POST /webhooks/products/update        → products/update
+ *   POST /webhooks/products/delete        → products/delete
+ *   POST /webhooks/inventory/update       → inventory_levels/update
+ *
+ * Bindings (wrangler.toml → vars / secrets):
+ *   SHOPIFY_WEBHOOK_SECRET   secret  — used to verify HMAC on every request
+ *   SHOPIFY_STORE            var
+ *   SHOPIFY_ADMIN_TOKEN      secret  — needed for inventory webhook fan-out lookup
+ *   SHOPIFY_API_VERSION      var
+ *   WEBFLOW_TOKEN            secret
+ *   WEBFLOW_COLLECTION_ID    var
+ *   WEBFLOW_SITE_ID          var (optional, enables publish)
+ *
+ * Inventory webhooks deliver inventory_item_id, not product_id, so we must
+ * look up the variant → product through the Admin API before upserting.
+ *
+ * Idempotency: each upsert keys on `shopify-id`. Replays of the same webhook
+ * are safe — the Webflow PATCH is a no-op when fieldData is unchanged.
+ */
+
+const WEBFLOW_API = 'https://api.webflow.com/v2';
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method !== 'POST') {
+      return new Response('method not allowed', { status: 405 });
+    }
+    const url = new URL(request.url);
+    const topic = url.pathname.replace(/^\/webhooks\//, '');
+    const raw = await request.text();
+
+    if (!(await verifyHmac(raw, request.headers.get('X-Shopify-Hmac-Sha256'), env.SHOPIFY_WEBHOOK_SECRET))) {
+      return new Response('invalid hmac', { status: 401 });
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      return new Response('invalid json', { status: 400 });
+    }
+
+    // Acknowledge fast; Shopify retries on >5s. Real work runs in waitUntil.
+    ctx.waitUntil(
+      handle(topic, payload, env).catch((e) => console.error('handler failed', topic, e)),
+    );
+    return new Response('ok', { status: 200 });
+  },
+};
+
+// --------------------------------------------------------------------------
+// HMAC verification — constant-time
+// --------------------------------------------------------------------------
+
+async function verifyHmac(rawBody, signature, secret) {
+  if (!signature || !secret) return false;
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, enc.encode(rawBody));
+  const expected = btoa(String.fromCharCode(...new Uint8Array(mac)));
+  return timingSafeEqual(expected, signature);
+}
+
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return mismatch === 0;
+}
+
+// --------------------------------------------------------------------------
+// Topic dispatch
+// --------------------------------------------------------------------------
+
+async function handle(topic, payload, env) {
+  switch (topic) {
+    case 'products/create':
+    case 'products/update':
+      return upsertProduct(payload, env);
+    case 'products/delete':
+      return deleteProduct(payload.id, env);
+    case 'inventory/update':
+    case 'inventory_levels/update':
+      return upsertProductByInventoryItem(payload.inventory_item_id, env);
+    default:
+      console.warn('unknown topic', topic);
+  }
+}
+
+// --------------------------------------------------------------------------
+// Shopify Admin API (only used when we need to resolve variant→product)
+// --------------------------------------------------------------------------
+
+async function shopifyAdmin(env, query, variables) {
+  const res = await fetch(
+    `https://${env.SHOPIFY_STORE}/admin/api/${env.SHOPIFY_API_VERSION || '2025-01'}/graphql.json`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Shopify-Access-Token': env.SHOPIFY_ADMIN_TOKEN,
+      },
+      body: JSON.stringify({ query, variables }),
+    },
+  );
+  if (!res.ok) throw new Error(`shopify admin ${res.status}: ${await res.text()}`);
+  const json = await res.json();
+  if (json.errors) throw new Error(JSON.stringify(json.errors));
+  return json.data;
+}
+
+const Q_PRODUCT_BY_INVENTORY_ITEM = `
+  query($id: ID!) {
+    inventoryItem(id: $id) {
+      variant { product { id handle title descriptionHtml totalInventory
+        featuredImage { url altText }
+        priceRangeV2 { minVariantPrice { amount currencyCode } }
+      } }
+    }
+  }
+`;
+
+async function upsertProductByInventoryItem(invId, env) {
+  const gid = `gid://shopify/InventoryItem/${invId}`;
+  const data = await shopifyAdmin(env, Q_PRODUCT_BY_INVENTORY_ITEM, { id: gid });
+  const product = data.inventoryItem?.variant?.product;
+  if (!product) return;
+  return upsertProduct(adminProductToWebhookShape(product), env);
+}
+
+function adminProductToWebhookShape(p) {
+  // Match the fields used by webhook payloads (REST shape) so upsertProduct
+  // can take either as input.
+  return {
+    id: p.id,
+    handle: p.handle,
+    title: p.title,
+    body_html: p.descriptionHtml,
+    image: p.featuredImage,
+    inventoryTotal: p.totalInventory,
+    minPrice: p.priceRangeV2?.minVariantPrice,
+  };
+}
+
+// --------------------------------------------------------------------------
+// Webflow upsert
+// --------------------------------------------------------------------------
+
+async function findWebflowItem(shopifyId, env) {
+  // Webflow CMS v2 supports filtering items by fieldData on list endpoint.
+  // Fall back to a paginated scan if filter is unavailable for the field type.
+  const url =
+    `${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items` +
+    `?fieldData.shopify-id=${encodeURIComponent(shopifyId)}&limit=1`;
+  const res = await wfFetch(url, env);
+  return res?.items?.[0] ?? null;
+}
+
+function productToFieldData(p) {
+  // Accepts either Shopify webhook (REST) or admin-graphql shape.
+  const id = p.admin_graphql_api_id ?? p.id;
+  const price = p.minPrice?.amount ?? p.variants?.[0]?.price ?? null;
+  const currency = p.minPrice?.currencyCode ?? p.currency ?? null;
+  const image = p.image?.url ?? p.image?.src ?? null;
+  return {
+    name: p.title,
+    slug: p.handle,
+    'shopify-id': typeof id === 'number' ? `gid://shopify/Product/${id}` : id,
+    handle: p.handle,
+    description: p.body_html ?? p.descriptionHtml ?? '',
+    price: price !== null ? parseFloat(price) : null,
+    currency,
+    'featured-image': image ? { url: image, alt: p.image?.alt ?? p.title } : null,
+    'in-stock': (p.inventoryTotal ?? p.total_inventory ?? 0) > 0,
+  };
+}
+
+async function upsertProduct(p, env) {
+  const fieldData = productToFieldData(p);
+  const existing = await findWebflowItem(fieldData['shopify-id'], env);
+  let itemId;
+  if (existing) {
+    await wfFetch(`${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items/${existing.id}`, env, {
+      method: 'PATCH',
+      body: JSON.stringify({ fieldData }),
+    });
+    itemId = existing.id;
+  } else {
+    const created = await wfFetch(`${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items`, env, {
+      method: 'POST',
+      body: JSON.stringify({ fieldData }),
+    });
+    itemId = created.id;
+  }
+  if (env.WEBFLOW_SITE_ID && itemId) {
+    await wfFetch(`${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items/publish`, env, {
+      method: 'POST',
+      body: JSON.stringify({ itemIds: [itemId] }),
+    });
+  }
+}
+
+async function deleteProduct(shopifyNumericId, env) {
+  const gid = `gid://shopify/Product/${shopifyNumericId}`;
+  const existing = await findWebflowItem(gid, env);
+  if (!existing) return;
+  await wfFetch(
+    `${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items/${existing.id}`,
+    env,
+    { method: 'DELETE' },
+  );
+}
+
+async function wfFetch(url, env, init = {}) {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${env.WEBFLOW_TOKEN}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...init.headers,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`webflow ${init.method || 'GET'} → ${res.status}: ${await res.text()}`);
+  }
+  return res.status === 204 ? null : res.json();
+}

--- a/headless-poc/sync/worker/worker.mjs
+++ b/headless-poc/sync/worker/worker.mjs
@@ -91,7 +91,7 @@ async function handle(topic, payload, env) {
     case 'products/update':
       return upsertProduct(payload, env);
     case 'products/delete':
-      return deleteProduct(payload.id, env);
+      return deleteProduct(payload.handle ?? payload.slug, env);
     case 'inventory/update':
     case 'inventory_levels/update':
       return upsertProductByInventoryItem(payload.inventory_item_id, env);
@@ -159,12 +159,21 @@ function adminProductToWebhookShape(p) {
 // Webflow upsert
 // --------------------------------------------------------------------------
 
-async function findWebflowItem(shopifyId, env) {
-  // Webflow CMS v2 supports filtering items by fieldData on list endpoint.
-  // Fall back to a paginated scan if filter is unavailable for the field type.
+// The Webflow CMS v2 List Items endpoint only supports `name` and `slug` as
+// query filters — `fieldData.<other>` is silently ignored and returns the
+// first page of all items, which would corrupt the mirror with duplicates
+// and mis-targeted patches. We therefore look up by slug, which is the
+// Shopify product handle in our schema and uniquely identifies a row.
+//
+// Trade-off: if a Shopify handle changes, the rename appears as a new
+// product to this lookup. The polling sync.mjs reconciles by `shopify-id`
+// across the full collection and will clean up the orphan on its next
+// pass — keep it scheduled (e.g. nightly) as a safety net.
+async function findWebflowItemBySlug(slug, env) {
+  if (!slug) return null;
   const url =
     `${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items` +
-    `?fieldData.shopify-id=${encodeURIComponent(shopifyId)}&limit=1`;
+    `?slug=${encodeURIComponent(slug)}`;
   const res = await wfFetch(url, env);
   return res?.items?.[0] ?? null;
 }
@@ -190,7 +199,7 @@ function productToFieldData(p) {
 
 async function upsertProduct(p, env) {
   const fieldData = productToFieldData(p);
-  const existing = await findWebflowItem(fieldData['shopify-id'], env);
+  const existing = await findWebflowItemBySlug(fieldData.slug, env);
   let itemId;
   if (existing) {
     await wfFetch(`${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items/${existing.id}`, env, {
@@ -213,9 +222,11 @@ async function upsertProduct(p, env) {
   }
 }
 
-async function deleteProduct(shopifyNumericId, env) {
-  const gid = `gid://shopify/Product/${shopifyNumericId}`;
-  const existing = await findWebflowItem(gid, env);
+async function deleteProduct(handle, env) {
+  // products/delete webhooks deliver the full product object including
+  // handle. If a future webhook variant ever drops the handle, the
+  // polling sync will reap the orphan on its next reconciliation run.
+  const existing = await findWebflowItemBySlug(handle, env);
   if (!existing) return;
   await wfFetch(
     `${WEBFLOW_API}/collections/${env.WEBFLOW_COLLECTION_ID}/items/${existing.id}`,

--- a/headless-poc/sync/worker/wrangler.toml
+++ b/headless-poc/sync/worker/wrangler.toml
@@ -1,0 +1,24 @@
+name = "omniflex-shopify-webhook-sync"
+main = "worker.mjs"
+compatibility_date = "2025-01-15"
+
+# Public vars (non-secret). Set with: wrangler deploy
+[vars]
+SHOPIFY_STORE = "omniflexfitness.myshopify.com"
+SHOPIFY_API_VERSION = "2025-01"
+WEBFLOW_COLLECTION_ID = "REPLACE_ME"
+# Optional — only needed if the worker should publish updated CMS items live.
+WEBFLOW_SITE_ID = "REPLACE_ME"
+
+# Secrets (set with: wrangler secret put <NAME>)
+# - SHOPIFY_WEBHOOK_SECRET
+# - SHOPIFY_ADMIN_TOKEN
+# - WEBFLOW_TOKEN
+
+[observability]
+enabled = true
+
+# Optional: route under a custom domain
+# [[routes]]
+# pattern = "webhooks.omniflex.example.com/*"
+# zone_name = "omniflex.example.com"

--- a/headless-poc/tests/README.md
+++ b/headless-poc/tests/README.md
@@ -1,0 +1,43 @@
+# End-to-end tests
+
+Playwright suite that exercises the headless storefront against a live staging Webflow site. Tests are skipped if `BASE_URL` is not set, so the suite is safe to run in CI without staging access.
+
+## Run locally
+
+```bash
+cd headless-poc/tests
+npm install
+npm run install:browsers           # one-time, ~300MB
+BASE_URL=https://omniflex.webflow.io \
+  PRODUCT_HANDLE=oversized-tee \
+  npm test
+```
+
+## What's covered
+
+- **PDP renders** — product title, price, and add-to-cart button appear from the Storefront API
+- **Add to cart + persistence** — line appears in the drawer, count badge updates, survives a page reload (localStorage cart ID)
+- **Checkout redirect** — drawer's checkout link points at a Shopify-hosted checkout origin
+- **PLP renders** — at least one product card on a collection page
+- **JSON-LD** — structured data is injected on PDP and parses as a `Product` schema
+
+## What's NOT covered (deliberate)
+
+- Actual order completion. The Bogus Gateway test order is best done manually first; automating it requires Shopify staging-store API tokens and a stable test-card flow.
+- Customer Account API login flow. The OAuth callback is hard to automate without exposing a test customer's credentials. Cover this with a manual checklist on each release.
+- Visual regression. Add `@playwright/test`'s `toHaveScreenshot()` once the design is locked.
+
+## CI
+
+Add a GitHub Actions workflow once a staging URL is stable:
+
+```yaml
+- uses: actions/setup-node@v4
+  with: { node-version: 20 }
+- run: cd headless-poc/tests && npm install
+- run: cd headless-poc/tests && npm run install:browsers
+- run: cd headless-poc/tests && npm test
+  env:
+    BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+    PRODUCT_HANDLE: ${{ secrets.STAGING_PRODUCT_HANDLE }}
+```

--- a/headless-poc/tests/e2e/cart.spec.mjs
+++ b/headless-poc/tests/e2e/cart.spec.mjs
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+const PRODUCT_HANDLE = process.env.PRODUCT_HANDLE;
+
+test.describe('headless cart flow', () => {
+  test.skip(!process.env.BASE_URL, 'BASE_URL not set — skipping live tests');
+
+  test('PDP renders product from Storefront API', async ({ page }) => {
+    test.skip(!PRODUCT_HANDLE, 'PRODUCT_HANDLE not set');
+    await page.goto(`/products/${PRODUCT_HANDLE}`);
+    await expect(page.locator('.of-product__title')).toBeVisible();
+    await expect(page.locator('.of-product__price')).not.toBeEmpty();
+    await expect(page.locator('.of-product__add')).toBeVisible();
+  });
+
+  test('add to cart populates the drawer and persists', async ({ page, context }) => {
+    test.skip(!PRODUCT_HANDLE, 'PRODUCT_HANDLE not set');
+
+    await page.goto(`/products/${PRODUCT_HANDLE}`);
+    await page.locator('.of-product__add:not([disabled])').click();
+
+    // Drawer should open and contain at least one line
+    await expect(page.locator('.of-drawer[aria-hidden="false"]')).toBeVisible();
+    await expect(page.locator('.of-drawer__line')).toHaveCount(1);
+
+    // Cart count badge updates
+    await expect(page.locator('[data-of-cart-count]').first()).toHaveText(/[1-9]/);
+
+    // Reload preserves the cart via localStorage
+    await page.reload();
+    await expect(page.locator('[data-of-cart-count]').first()).toHaveText(/[1-9]/);
+  });
+
+  test('checkout link redirects to Shopify-hosted checkout', async ({ page }) => {
+    test.skip(!PRODUCT_HANDLE, 'PRODUCT_HANDLE not set');
+
+    await page.goto(`/products/${PRODUCT_HANDLE}`);
+    await page.locator('.of-product__add:not([disabled])').click();
+    const checkout = page.locator('.of-drawer__checkout');
+    await expect(checkout).toHaveAttribute('href', /\.myshopify\.com|\.shopifypreview\.com|\/checkouts\//);
+  });
+
+  test('PLP renders synced products', async ({ page }) => {
+    await page.goto('/shop');
+    await expect(page.locator('.of-collection__card, [data-of-add-to-cart]')).not.toHaveCount(0);
+  });
+
+  test('JSON-LD is injected on PDP for SEO', async ({ page }) => {
+    test.skip(!PRODUCT_HANDLE, 'PRODUCT_HANDLE not set');
+    await page.goto(`/products/${PRODUCT_HANDLE}`);
+    await page.waitForSelector('script[data-of-jsonld="product"]');
+    const ld = await page.locator('script[data-of-jsonld="product"]').textContent();
+    const parsed = JSON.parse(ld);
+    expect(parsed['@type']).toBe('Product');
+    expect(parsed.name).toBeTruthy();
+    expect(parsed.offers).toBeTruthy();
+  });
+});

--- a/headless-poc/tests/package.json
+++ b/headless-poc/tests/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "omniflex-headless-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=20" },
+  "scripts": {
+    "test": "playwright test --config playwright.config.mjs",
+    "test:headed": "playwright test --headed --config playwright.config.mjs",
+    "install:browsers": "playwright install --with-deps"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/headless-poc/tests/playwright.config.mjs
+++ b/headless-poc/tests/playwright.config.mjs
@@ -1,0 +1,28 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Playwright config for end-to-end tests against the staging Webflow site.
+ *
+ * Set in .env or CI:
+ *   BASE_URL              https://<your-staging-domain>
+ *   PRODUCT_HANDLE        a real synced Shopify product handle (defaults to the first PLP card)
+ */
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: process.env.BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+    { name: 'firefox',  use: { browserName: 'firefox' } },
+    { name: 'webkit',   use: { browserName: 'webkit' } },
+  ],
+});

--- a/headless-poc/webflow-embeds/cart-icon.html
+++ b/headless-poc/webflow-embeds/cart-icon.html
@@ -1,0 +1,14 @@
+<!--
+  Cart icon — paste anywhere in the Webflow header (or use a Designer button
+  with these custom attributes set on the element).
+
+    data-of-cart-toggle      → opens the drawer when clicked
+    data-of-cart-count       → element receives live line-item count
+
+  No further setup needed. The drawer DOM is injected once by the script.
+-->
+
+<a href="#" data-of-cart-toggle aria-label="Open cart">
+  Cart
+  <span data-of-cart-count aria-live="polite">0</span>
+</a>

--- a/headless-poc/webflow-embeds/pdp-template.html
+++ b/headless-poc/webflow-embeds/pdp-template.html
@@ -1,0 +1,11 @@
+<!--
+  PDP — paste into the Webflow CMS Template Page for the "Products" collection.
+
+  Wrap any container Div with the following attributes:
+    data-of-product = "{{ Slug }}"   (CMS-bound to the product slug)
+
+  The script will fetch the product live from Shopify Storefront API
+  and render variant picker + add-to-cart inside this container.
+-->
+
+<div data-of-product="{{wf {&quot;path&quot;:&quot;slug&quot;,&quot;type&quot;:&quot;PlainText&quot;\} }}"></div>

--- a/headless-poc/webflow-embeds/plp-template.html
+++ b/headless-poc/webflow-embeds/plp-template.html
@@ -1,0 +1,16 @@
+<!--
+  PLP / Collection page — two options:
+
+  Option 1 (recommended): Use Webflow's CMS Collection List bound to the
+  synced "Products" collection so the layout is fully Webflow-designed.
+  Add `data-of-add-to-cart` and `data-of-handle` on each card's button:
+
+    <a data-of-add-to-cart data-of-handle="{{ Slug }}">Add to cart</a>
+
+  Option 2 (script-rendered): Drop a single empty container that the script
+  populates. Use this for quick-and-dirty pages where you don't want to wire
+  the CMS. Replace "all" with the Shopify collection handle.
+-->
+
+<!-- Option 2 -->
+<div data-of-collection="all" data-of-limit="24"></div>

--- a/headless-poc/webflow-embeds/site-wide-head.html
+++ b/headless-poc/webflow-embeds/site-wide-head.html
@@ -1,0 +1,16 @@
+<!--
+  Paste into Webflow → Site Settings → Custom Code → "Inside <head> tag"
+  Replace SHOP and STOREFRONT_TOKEN before going live.
+
+  jsDelivr serves any file from a public GitHub repo at @<branch-or-tag>/<path>.
+  Pin to a commit SHA in production, never to "main".
+-->
+<meta name="of-shop"        content="omniflexfitness.myshopify.com">
+<meta name="of-token"       content="STOREFRONT_API_PUBLIC_TOKEN_HERE">
+<meta name="of-api-version" content="2025-01">
+
+<link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/gh/OmniFlexFitness/OmniFlex-Shopify-Theme@claude/webflow-integration-investigation-Hr7vb/headless-poc/omniflex-headless.css">
+
+<script type="module"
+  src="https://cdn.jsdelivr.net/gh/OmniFlexFitness/OmniFlex-Shopify-Theme@claude/webflow-integration-investigation-Hr7vb/headless-poc/omniflex-headless.js"></script>

--- a/headless-poc/webflow-setup.md
+++ b/headless-poc/webflow-setup.md
@@ -1,0 +1,127 @@
+# Webflow Setup Walkthrough
+
+End‑to‑end steps to wire a Webflow site to Shopify using this PoC. Allow ~2 hours the first time.
+
+## 0. Prerequisites
+
+- A Shopify store where you are an admin (e.g. `omniflexfitness.myshopify.com`)
+- A Webflow site (free Starter plan is fine for setup; a paid CMS plan is required to publish CMS-templated pages)
+- Node.js ≥ 20 locally for the sync script
+
+## 1. Create a Shopify Storefront API token (public)
+
+This token is **safe to put in client-side HTML** — it's the public token Shopify designs for headless storefronts.
+
+1. In Shopify admin → **Settings** → **Apps and sales channels** → **Develop apps** → **Create an app**
+2. Name it `Webflow Headless Storefront`
+3. Configure **Storefront API access** with these scopes:
+   - `unauthenticated_read_product_listings`
+   - `unauthenticated_read_product_inventory`
+   - `unauthenticated_read_product_tags`
+   - `unauthenticated_write_checkouts`
+   - `unauthenticated_read_checkouts`
+   - `unauthenticated_write_customers` (only if you plan to add a customer login flow)
+4. **Install app** → copy the **Storefront API access token** (starts with `shpat_...` for older keys or a newer prefix for current ones)
+
+## 2. Create a Shopify Admin API token (private)
+
+This is for the sync script only. **Never put this in client code.**
+
+1. Same app from step 1 → **Configuration** → **Admin API integration**
+2. Scopes: `read_products`, `read_inventory`, `read_product_listings`
+3. Reveal and copy the **Admin API access token**
+
+## 3. Create the Webflow site + CMS collection
+
+1. In Webflow, create a new site (or use an existing one)
+2. **CMS** → **Create new collection** → name it `Products`
+3. Add these fields **(field slugs must match exactly)**:
+   | Field name      | Type       | Slug             | Required |
+   |---|---|---|---|
+   | Name            | Plain text | `name`           | yes |
+   | Slug            | Plain text | `slug`           | yes |
+   | Shopify ID      | Plain text | `shopify-id`     | yes |
+   | Handle          | Plain text | `handle`         | no  |
+   | Description     | Rich text  | `description`    | no  |
+   | Price           | Number     | `price`          | no  |
+   | Currency        | Plain text | `currency`       | no  |
+   | Featured image  | Image      | `featured-image` | no  |
+   | In stock        | Switch     | `in-stock`       | no  |
+4. Create the **Template Page** for this collection. It will be the PDP. Drop in the contents of `webflow-embeds/pdp-template.html` as an HTML embed and bind the `data-of-product` attribute to the CMS slug.
+
+## 4. Generate a Webflow API token
+
+1. Webflow → **Workspace settings** → **Integrations** → **API access** → **Generate API token**
+2. Permissions: `CMS: read+write`, `Sites: read+write` (the `Sites` scope is only needed if you want the sync script to publish items live; otherwise read-only is fine and items will save as drafts).
+3. Note the **Site ID** (in Webflow project settings) and the **Collection ID** (Designer → CMS panel → collection settings).
+
+## 5. Configure the static script
+
+Edit `webflow-embeds/site-wide-head.html`:
+- Set the `of-shop` meta to your `*.myshopify.com` domain
+- Set the `of-token` meta to the **Storefront API public token** (from step 1)
+- Confirm the `<script>` and `<link>` URLs point at the right branch/commit. **Production should pin to a commit SHA**, not a branch.
+
+Paste the file's contents into:
+**Webflow → Site Settings → Custom Code → Inside `<head>` tag**
+
+Save. Publish to staging.
+
+## 6. Add cart UI to the site
+
+1. In the Webflow Designer header, drag in a **Link Block** for the cart icon
+2. Add custom attributes to the link: `data-of-cart-toggle` (no value) and a child `<span>` with attribute `data-of-cart-count`
+3. Reference: `webflow-embeds/cart-icon.html`
+
+The drawer itself is injected into the DOM at runtime — you don't need to design it in Webflow. Once the basic flow works, you can override the `.of-drawer__*` styles in your global CSS in Webflow to match the brand.
+
+## 7. Wire up PDP
+
+On the CMS Template Page for **Products**:
+1. Drag a **Div Block** where the product UI should appear
+2. Open custom attributes → add `data-of-product` with value bound to the CMS field **Slug** (use the Webflow field-binding picker, not a literal)
+3. Publish to staging
+
+Open `https://yoursite.webflow.io/products/<some-handle>` — the script should fetch the live Shopify product and render the variant picker.
+
+## 8. Wire up PLP
+
+Choose ONE approach:
+
+**A. Use Webflow CMS Collection List** (recommended, fully Webflow-designed):
+- Drag a Collection List bound to `Products`
+- Inside each card add a button with attributes `data-of-add-to-cart` + `data-of-handle="{{ Slug }}"`
+- Bind name, image, price to the CMS fields synced by the script
+
+**B. Script-rendered grid** (quick start):
+- Drop an embed: `<div data-of-collection="all" data-of-limit="24"></div>`
+
+## 9. Run the sync
+
+```bash
+cd headless-poc/sync
+cp .env.example .env
+# fill in tokens
+npm run sync:dry      # preview changes
+npm run sync          # one-shot sync
+npm run sync:watch    # poll every 5 minutes
+```
+
+For production, deploy as a Cloudflare Worker on a Cron Trigger (every 10–15 min) or a Render/Railway cron job. Webhook-driven sync (Shopify product/update webhook → sync handler) is the next iteration.
+
+## 10. Test the full flow
+
+1. Visit a PDP on staging → pick a variant → **Add to cart**
+2. Cart drawer opens, line item appears
+3. **Checkout** → redirects to `*.myshopify.com/checkout` (Shopify-hosted)
+4. Complete a test order with a Bogus Gateway payment
+
+If steps 1–4 all succeed, the headless loop is working end-to-end.
+
+## Common issues
+
+- **CORS error in browser console**: check the Storefront token is correct and the app from step 1 is installed.
+- **`product` returns null**: the handle in `data-of-product` does not match a Shopify handle. Webflow field binding must point at the synced `slug` field, which the sync script copies from `product.handle`.
+- **Sync script 401**: regenerate the Webflow token with `CMS: read+write`.
+- **Sync runs but PDP renders "Product not found"**: the storefront token in the `<meta>` is wrong, or the Shopify app from step 1 wasn't given the `unauthenticated_read_product_listings` scope.
+- **Variants out of stock when they shouldn't be**: live inventory comes from Storefront API, not the synced CMS items. The CMS `in-stock` field is a coarse "any inventory > 0" flag for use in PLP filtering only.


### PR DESCRIPTION
## Summary
- Adds `docs/webflow-integration-investigation.md` analyzing whether the OmniFlex storefront can be rebuilt with Webflow as the frontend while keeping commerce on Shopify.
- Surveys the current theme (Dawn 12.0.0, ~21K lines of Liquid, 60+ sections, metaobject-driven supplement pages, 28 locales, customer account flows, custom 3D/video features) and maps each surface to its Shopify dependency.
- Compares four architecture options — Buy Button SDK, Hybrid (Webflow `www` + Shopify `shop`), Webflow-as-headless with a sync layer, and full headless (Hydrogen/Next.js) — with effort estimates and risks.
- **Recommendation:** Hybrid (Option B). Lowest risk, preserves variants/metaobjects/customer accounts/Markets/Shop Pay, and unlocks Webflow's design and CMS for marketing pages. Suggests a 2-week spike on a single Webflow page (About/Founder) with a shared header rebuild before committing.

## Test plan
- [ ] Stakeholder review of the four options and recommendation in `docs/webflow-integration-investigation.md`
- [ ] Confirm assumptions about subscriptions/apps/Markets usage are accurate for current OmniFlex setup
- [ ] Decide whether to scope the proposed 2-week Option B spike

https://claude.ai/code/session_012KjFqHKqEB4ey6sizbNdVG

---
_Generated by [Claude Code](https://claude.ai/code/session_012KjFqHKqEB4ey6sizbNdVG)_