### PR TITLE
Add interactive wallpaper banner section

### DIFF
--- a/assets/interactive-wallpaper-shaders.js
+++ b/assets/interactive-wallpaper-shaders.js
@@ -1,0 +1,1035 @@
+/*
+ * Interactive Wallpaper Shaders
+ *
+ * Nine WebGL2 fragment-shader "wallpapers" that respond to cursor position
+ * and clicks. Exported on window.OmniflexInteractiveWallpapers so the
+ * `interactive-wallpaper-banner` section can pick one by name at render time.
+ */
+(function () {
+  const VERT = `#version 300 es
+layout(location=0) in vec2 a_pos;
+void main(){ gl_Position = vec4(a_pos, 0, 1); }`;
+
+  const COMMON = `#version 300 es
+precision highp float;
+uniform vec2 R;
+uniform float T;
+uniform vec2 M;
+uniform vec2 C;
+uniform float CT;
+out vec4 O;
+
+#define PI 3.14159265359
+#define TAU 6.28318530718
+
+float h21(vec2 p){
+  p = fract(p * vec2(234.34, 435.345));
+  p += dot(p, p + 34.23);
+  return fract(p.x * p.y);
+}
+vec2 h22(vec2 p){
+  vec3 a = fract(vec3(p.xyx) * vec3(.1031, .103, .0973));
+  a += dot(a, a.yzx + 33.33);
+  return fract((a.xx + a.yz) * a.zy);
+}
+float vnoise(vec2 p){
+  vec2 i = floor(p), f = fract(p);
+  f = f * f * (3. - 2. * f);
+  return mix(
+    mix(h21(i), h21(i + vec2(1, 0)), f.x),
+    mix(h21(i + vec2(0, 1)), h21(i + vec2(1, 1)), f.x), f.y);
+}
+float fbm(vec2 p){
+  float v = 0., a = .5;
+  mat2 r = mat2(.877, .479, -.479, .877);
+  for(int i = 0; i < 6; i++){ v += a * vnoise(p); p = r * p * 2.; a *= .5; }
+  return v;
+}
+float grain(vec2 p, float t){ return (h21(p + fract(t)) - .5) * .018; }
+`;
+
+  const NEBULA = `
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .12;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+  float md = length(p - mp);
+
+  vec2 warp = (p - mp) / (md * md + .3) * .2;
+  vec2 q = p + warp;
+
+  float n1 = fbm(q * 2. + vec2(t, t * .7));
+  float n2 = fbm(q * 3. + vec2(-t * .5, t * .3) + n1 * .5);
+  float n3 = fbm(q * 1.8 + n2 * .4 + vec2(t * .2, -t * .4));
+
+  vec3 c = vec3(.008, .008, .03);
+  c = mix(c, vec3(.04, .06, .2), smoothstep(.25, .55, n1));
+  c = mix(c, vec3(.15, .06, .35), smoothstep(.35, .65, n2));
+  c += vec3(.1, .22, .6) * pow(max(0., smoothstep(.5, .9, n3)), 2.) * .6;
+  c += vec3(.35, .15, .6) * pow(max(0., smoothstep(.6, .95, n2 * n3)), 3.) * .4;
+  c += vec3(.2, .4, .9) * pow(max(0., smoothstep(.55, .85, n1 + n2 * .5)), 4.) * .25;
+
+  c += vec3(.1, .18, .5) * exp(-md * md * 3.) * .7;
+  c += vec3(.2, .15, .5) * exp(-md * md * 12.) * .35;
+
+  float ct = T - CT;
+  if(ct < 4.){
+    vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+    float cd = length(q - cp);
+    float ring = abs(cd - ct * .7);
+    c += vec3(.3, .35, .9) * smoothstep(.08, 0., ring) * exp(-ct * .8) * 1.5;
+    c += vec3(.2, .1, .5) * smoothstep(.2, 0., abs(cd - ct * .7 - .15)) * exp(-ct * 1.2) * .5;
+  }
+
+  c *= 1. - dot((uv - .5) * 1.3, (uv - .5) * 1.3);
+  c += grain(gl_FragCoord.xy, T);
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const HORIZON = `
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+
+  vec2 tilt = (M - .5) * .25;
+  float horizon = -.05 + tilt.y * .2;
+  vec3 c = vec3(.008, .005, .025);
+
+  c = mix(c, vec3(.02, .015, .06), smoothstep(horizon - .2, horizon + .6, p.y));
+
+  vec2 sunP = vec2(tilt.x * .4, horizon + .22);
+  float sunD = length(p - sunP);
+  c += vec3(.2, .08, .4) * exp(-sunD * 3.);
+  c += vec3(.08, .15, .5) * exp(-sunD * 6.);
+  c += vec3(.4, .2, .7) * exp(-sunD * 15.);
+  c += vec3(.7, .5, 1.) * exp(-sunD * 40.) * .5;
+
+  if(p.y > horizon + .05){
+    vec2 sp = (p + tilt * .3) * 180.;
+    vec2 si = floor(sp);
+    float star = h21(si);
+    if(star > .97){
+      vec2 sf = fract(sp) - .5;
+      float sd = length(sf);
+      float tw = sin(T * 2. + star * 100.) * .3 + .7;
+      c += vec3(.5, .6, 1.) * smoothstep(.1, 0., sd) * tw * (star - .97) * 33. * .35;
+    }
+  }
+
+  if(p.y < horizon){
+    float gy = horizon - p.y;
+    float gz = .3 / (gy + .005);
+    float gx = (p.x + tilt.x * .5) * gz;
+    float t = T * .35;
+
+    float fx = fract(gx * .5 + .5);
+    float fz = fract(gz * .08 + t + .5);
+    float lx = abs(fx - .5);
+    float lz = abs(fz - .5);
+
+    float lineX = smoothstep(max(.008, fwidth(fx) * 1.5), 0., lx - .01);
+    float lineZ = smoothstep(max(.008, fwidth(fz) * 1.5), 0., lz - .01);
+    float grid = max(lineX, lineZ);
+
+    float fade = exp(-gy * .6) * smoothstep(0., .015, gy);
+    vec3 gridCol = vec3(.1, .25, .7);
+
+    float ct = T - CT;
+    if(ct < 5.){
+      vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+      float cgy = horizon - cp.y;
+      if(cgy > .01){
+        float cgz = .3 / (cgy + .005);
+        float cgx = (cp.x + tilt.x * .5) * cgz;
+        float dist = length(vec2(gx - cgx, gz - cgz) * .08);
+        float ripple = sin(dist * 15. - ct * 6.) * exp(-ct * 1.) * exp(-dist * .3);
+        grid += abs(ripple) * .4;
+        gridCol = mix(gridCol, vec3(.4, .2, .8), abs(ripple) * .5);
+      }
+    }
+
+    c += gridCol * grid * fade * .55;
+    c += vec3(.1, .12, .45) * exp(-gy * 18.) * .5;
+  }
+
+  c *= .96 + .04 * sin(gl_FragCoord.y * 1.5);
+  c *= 1. - dot((uv - .5) * 1.2, (uv - .5) * 1.2);
+  c += grain(gl_FragCoord.xy, T);
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const VORONOI = `
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .15;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+
+  float md = length(p - mp);
+  p += (p - mp) * exp(-md * md * 4.) * .35;
+
+  float ct = T - CT;
+  if(ct < 4.){
+    vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+    float cd = length(p - cp);
+    float wave = sin(cd * 12. - ct * 6.) * exp(-ct * 1.2) * .06;
+    p += normalize(p - cp + .0001) * wave;
+  }
+
+  vec2 sp = p * 5.;
+  vec2 ip = floor(sp);
+  vec2 fp = fract(sp);
+
+  float md1 = 10., md2 = 10.;
+  vec2 mpt = vec2(0.);
+  float mid = 0.;
+
+  for(int y = -1; y <= 1; y++){
+    for(int x = -1; x <= 1; x++){
+      vec2 nb = vec2(float(x), float(y));
+      vec2 cell = ip + nb;
+      vec2 pt = h22(cell);
+      pt = .5 + .4 * sin(t * 3. + pt * TAU);
+      vec2 diff = nb + pt - fp;
+      float d = length(diff);
+      if(d < md1){ md2 = md1; md1 = d; mpt = cell + pt; mid = h21(cell); }
+      else if(d < md2){ md2 = d; }
+    }
+  }
+
+  float edge = md2 - md1;
+  vec3 c = mix(vec3(.015, .012, .04), vec3(.025, .015, .05), mid);
+
+  vec3 edgeCol = mix(vec3(.12, .3, .85), vec3(.4, .15, .75), sin(mid * 15.) * .5 + .5);
+  c += edgeCol * smoothstep(.12, 0., edge) * .7;
+  c += vec3(.3, .45, .95) * smoothstep(.04, 0., edge) * .5;
+
+  float pulse = sin(T * .5 + mid * TAU) * .5 + .5;
+  c += edgeCol * .025 * pulse * (1. - smoothstep(.12, 0., edge));
+
+  if(ct < 3.){
+    vec2 cp2 = (C - .5) * vec2(R.x / R.y, 1.) * 5.;
+    float clickD = length(mpt - cp2 * .8);
+    float shatter = exp(-clickD * .4) * exp(-ct * 1.2);
+    c += edgeCol * shatter * 1.5;
+    float frac = abs(sin(mid * 50. + clickD * 3.));
+    c += vec3(.15, .25, .65) * smoothstep(.02, 0., abs(frac - .5) - .4) * shatter * .5;
+  }
+
+  float mg2 = length(sp - mp * 5.);
+  c += vec3(.04, .08, .22) * exp(-mg2 * mg2 * .08);
+
+  c *= 1. - dot((uv - .5) * 1.3, (uv - .5) * 1.3);
+  c += grain(gl_FragCoord.xy, T);
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const SYNAPSE = `
+#define N 16
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .28;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+  vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+  float ct = T - CT;
+
+  vec2 nodes[N];
+  float fireFx[N];
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float ang = fi * 1.618 * TAU + sin(t * .3 + fi * .5) * .4;
+    float rad = .12 + sqrt(fi / float(N)) * .55;
+    vec2 base = vec2(cos(ang), sin(ang)) * rad * vec2(R.x / R.y * .9, 1.);
+    float n1 = sin(t * 1.1 + fi * 2.7) * cos(t * .8 + fi * 1.9);
+    base += vec2(sin(t * 1.3 + fi * 1.5 + n1 * 3.),
+                 cos(t * 1.05 + fi * 2.1 + n1 * 3.)) * .11;
+
+    vec2 toM = base - mp;
+    float md = length(toM);
+    float vortex = exp(-md * md * 1.5);
+    vec2 perp = vec2(-toM.y, toM.x);
+    base += perp * vortex * sin(T * 1.3) * .18;
+    base -= toM * vortex * .12;
+
+    nodes[i] = base;
+
+    float fireDelay = length(base - cp) * 2.4;
+    float fireT = ct - fireDelay;
+    fireFx[i] = (fireT > 0. && fireT < 2.5)
+      ? exp(-fireT * 1.6) * smoothstep(0., .08, fireT) : 0.;
+  }
+
+  vec3 c = vec3(.006, .005, .025);
+  float nodeGlow = 0.;
+  float coreGlow = 0.;
+  vec3 lineAccum = vec3(0.);
+
+  const float THRESH = .4;
+
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float d = length(p - nodes[i]);
+    float pls = sin(T * 1.4 + fi * 2.4) * .25 + .75;
+    float fb = fireFx[i];
+    nodeGlow += .0035 / (d * d + .0006) * pls * (1. + fb * 5.);
+    coreGlow += .0006 / (d * d + .00008) * (1. + fb * 8.);
+
+    vec2 ab = mp - nodes[i];
+    float ablen2 = dot(ab, ab);
+    float ablen = sqrt(ablen2);
+    if(ablen < THRESH * 1.5){
+      float tp = clamp(dot(p - nodes[i], ab) / max(ablen2, .0001), 0., 1.);
+      float lineD = length(p - (nodes[i] + ab * tp));
+      float alpha = pow(1. - ablen / (THRESH * 1.5), 1.4);
+      float lineW = .00055 / (lineD * lineD + .00005);
+      vec3 col = mix(vec3(.3, .55, 1.2), vec3(.7, .35, 1.1), fract(fi * .41));
+      lineAccum += col * lineW * alpha * 1.4;
+    }
+
+    for(int j = i + 1; j < N; j++){
+      vec2 a = nodes[i], b = nodes[j];
+      vec2 ab2 = b - a;
+      float ablen2_2 = dot(ab2, ab2);
+      float ablen_2 = sqrt(ablen2_2);
+      if(ablen_2 < THRESH){
+        float tp = clamp(dot(p - a, ab2) / max(ablen2_2, .0001), 0., 1.);
+        float lineD = length(p - (a + ab2 * tp));
+        float alpha = pow(1. - ablen_2 / THRESH, 1.5);
+
+        float flow = sin(tp * 14. - T * 3. + fi * 2.) * .5 + .5;
+        flow = pow(flow, 5.);
+
+        float fbi = fireFx[i], fbj = fireFx[j];
+        float boltI = fbi > .001
+          ? smoothstep(.15, 0., abs(tp - (1. - fbi * 1.1))) * fbi * 4. : 0.;
+        float boltJ = fbj > .001
+          ? smoothstep(.15, 0., abs(tp - fbj * 1.1)) * fbj * 4. : 0.;
+        float edgeFire = max(fbi, fbj) * 2.;
+
+        float lineW = .00045 / (lineD * lineD + .00004);
+        vec3 col = mix(vec3(.15, .35, 1.), vec3(.55, .18, .98),
+                       fract(fi * .31 + float(j) * .77));
+        vec3 fireCol = vec3(.7, .85, 1.3);
+        lineAccum += col * lineW * alpha * (1. + flow * 1.6 + edgeFire);
+        lineAccum += fireCol * lineW * alpha * (boltI + boltJ);
+      }
+    }
+  }
+
+  c += vec3(.3, .5, 1.) * nodeGlow * .16;
+  c += vec3(.75, .85, 1.) * pow(coreGlow, 1.1) * 2.5;
+  c += lineAccum * .42;
+
+  float bg = fbm(p * 2.2 + t * .25);
+  c += vec3(.025, .035, .11) * bg * .5;
+
+  c += vec3(.08, .14, .5) * exp(-length(p - mp) * 2.4) * .3;
+
+  c *= 1. - dot((uv - .5) * 1.3, (uv - .5) * 1.3);
+  c += grain(gl_FragCoord.xy, T);
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const SYNAPSE_NOIR = `
+#define N 14
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .25;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+  vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+  float ct = T - CT;
+  float glitch = ct < 1.8 ? exp(-ct * 2.2) : 0.;
+
+  vec2 nodes[N];
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float ang = fi * 1.618 * TAU + sin(t * .3 + fi * .5) * .35;
+    float rad = .14 + sqrt(fi / float(N)) * .52;
+    vec2 base = vec2(cos(ang), sin(ang)) * rad * vec2(R.x / R.y * .9, 1.);
+    base += vec2(sin(t * 1.3 + fi * 1.7),
+                 cos(t * 1.05 + fi * 2.3)) * .08;
+    vec2 toM = mp - base;
+    float md = length(toM);
+    base += toM * exp(-md * md * 1.8) * .14;
+    nodes[i] = base;
+  }
+
+  vec3 c = vec3(.005, .003, .02);
+  float nodeGlow = 0.;
+  float coreGlow = 0.;
+  vec3 lineAccum = vec3(0.);
+
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float d = length(p - nodes[i]);
+    float pls = sin(T * 1.5 + fi * 2.4) * .3 + .7;
+    nodeGlow += .0035 / (d * d + .0006) * pls;
+    coreGlow += .0008 / (d * d + .00008);
+
+    vec2 ab = mp - nodes[i];
+    float ablen2 = dot(ab, ab);
+    float ablen = sqrt(ablen2);
+    if(ablen < .6){
+      float tp = clamp(dot(p - nodes[i], ab) / max(ablen2, .0001), 0., 1.);
+      float lineD = length(p - (nodes[i] + ab * tp));
+      float alpha = pow(1. - ablen / .6, 1.4);
+      float lineW = .00055 / (lineD * lineD + .00005);
+      vec3 col = mix(vec3(0., .85, 1.1), vec3(1., .18, .85), fract(fi * .41));
+      lineAccum += col * lineW * alpha * 1.5;
+    }
+
+    for(int j = i + 1; j < N; j++){
+      vec2 a = nodes[i];
+      vec2 ab2 = nodes[j] - a;
+      float ablen2_2 = dot(ab2, ab2);
+      float ablen_2 = sqrt(ablen2_2);
+      if(ablen_2 < .42){
+        float tp = clamp(dot(p - a, ab2) / max(ablen2_2, .0001), 0., 1.);
+        float lineD = length(p - (a + ab2 * tp));
+        float alpha = pow(1. - ablen_2 / .42, 1.5);
+        float flow = sin(tp * 14. - T * 3.5 + fi * 2.) * .5 + .5;
+        flow = pow(flow, 4.);
+
+        float chromaPulse = 0.;
+        if(glitch > .01){
+          float dc = min(length(nodes[i] - cp), length(nodes[j] - cp));
+          float ringT = ct * 1.4;
+          chromaPulse = exp(-abs(dc - ringT) * 4.5) * glitch * 4.;
+        }
+
+        float pal = fract(fi * .31 + float(j) * .77);
+        vec3 col;
+        if(pal < .34) col = vec3(0., .9, 1.1);
+        else if(pal < .67) col = vec3(1., .15, .8);
+        else col = vec3(.45, .2, 1.1);
+
+        float lineW = .00045 / (lineD * lineD + .00004);
+        lineAccum += col * lineW * alpha * (1. + flow * 1.4 + chromaPulse);
+      }
+    }
+  }
+
+  c += vec3(.7, .35, 1.) * nodeGlow * .12;
+  c += vec3(1., .85, 1.1) * pow(coreGlow, 1.05) * 1.8;
+  c += lineAccum * .45;
+
+  c += vec3(.04, .008, .07) * pow(1. - uv.y, 3.) * .8;
+  c += vec3(.015, .005, .04) * (.5 + .5 * sin(uv.x * 40. + sin(uv.x * 7.) * 5.)) * pow(1. - uv.y, 6.) * .5;
+
+  c *= .88 + .12 * sin(gl_FragCoord.y * 1.6 + T * 2.);
+
+  if(glitch > .005){
+    float dc = length(p - cp);
+    float ringT = ct * 1.2;
+    float ringR = sin((dc - ringT - .01) * 28.) * exp(-abs(dc - ringT - .01) * 5.5);
+    float ringG = sin((dc - ringT) * 28.) * exp(-abs(dc - ringT) * 5.5);
+    float ringB = sin((dc - ringT + .01) * 28.) * exp(-abs(dc - ringT + .01) * 5.5);
+    c.r += ringR * glitch * .8;
+    c.g += ringG * glitch * .35;
+    c.b += ringB * glitch * .7;
+
+    float barY = floor(p.y * 14. + T * 6.);
+    float barRand = h21(vec2(barY, floor(T * 12.)));
+    if(barRand > .7){
+      float bar = smoothstep(.4, 0., abs(fract(p.y * 14. + T * 6.) - .5) - .1);
+      c.r += bar * glitch * .6;
+      c.b += bar * glitch * .4;
+    }
+  }
+
+  c += vec3(.4, .08, .7) * exp(-length(p - mp) * 2.4) * .35;
+  c += vec3(.05, .5, .7) * exp(-length(p - mp) * 5.5) * .3;
+
+  c *= 1. - dot((uv - .5) * 1.4, (uv - .5) * 1.4) * .85;
+  c += grain(gl_FragCoord.xy, T) * 1.4;
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const SYNAPSE_BLOOM = `
+#define N 12
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .25;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+  vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+  float ct = T - CT;
+
+  vec2 nodes[N];
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float ang = fi * 1.618 * TAU + sin(t * .4 + fi) * .3;
+    float rad = .15 + sqrt(fi / float(N)) * .5;
+    vec2 base = vec2(cos(ang), sin(ang)) * rad * vec2(R.x / R.y * .9, 1.);
+    base += vec2(sin(t * 1.2 + fi * 1.6),
+                 cos(t * .9 + fi * 2.1)) * .1;
+    vec2 toM = mp - base;
+    float md = length(toM);
+    base += toM * exp(-md * md * 1.5) * .16;
+    nodes[i] = base;
+  }
+
+  vec3 c = vec3(.008, .005, .03);
+  float nodeGlow = 0.;
+  float coreGlow = 0.;
+  vec3 lineAccum = vec3(0.);
+  vec3 particleGlow = vec3(0.);
+
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float d = length(p - nodes[i]);
+    float pls = sin(T * 1.3 + fi * 2.4) * .3 + .7;
+    nodeGlow += .004 / (d * d + .0006) * pls;
+    coreGlow += .0008 / (d * d + .0001);
+
+    for(int pi = 0; pi < 4; pi++){
+      float pf = float(pi);
+      float pAng = (T * .6 + fi * 1.7 + pf * 1.57) * (1. + pf * .25);
+      float pRad = .025 + pf * .013 + .008 * sin(T + fi + pf);
+      vec2 partP = nodes[i] + vec2(cos(pAng), sin(pAng)) * pRad;
+      float pd = length(p - partP);
+      vec3 pcol = mix(vec3(.4, .65, 1.3), vec3(.7, .4, 1.2), fract(fi * .3 + pf * .2));
+      particleGlow += pcol * .00006 / (pd * pd + .00002);
+    }
+
+    vec2 ab = mp - nodes[i];
+    float ablen2 = dot(ab, ab);
+    float ablen = sqrt(ablen2);
+    if(ablen < .6){
+      float tp = clamp(dot(p - nodes[i], ab) / max(ablen2, .0001), 0., 1.);
+      float lineD = length(p - (nodes[i] + ab * tp));
+      float alpha = pow(1. - ablen / .6, 1.4);
+      float lineW = .00055 / (lineD * lineD + .00005);
+      vec3 col = mix(vec3(.35, .6, 1.2), vec3(.7, .4, 1.15), fract(fi * .41));
+      lineAccum += col * lineW * alpha * 1.5;
+    }
+
+    for(int j = i + 1; j < N; j++){
+      vec2 a = nodes[i];
+      vec2 ab2 = nodes[j] - a;
+      float ablen2_2 = dot(ab2, ab2);
+      float ablen_2 = sqrt(ablen2_2);
+      if(ablen_2 < .42){
+        float tp = clamp(dot(p - a, ab2) / max(ablen2_2, .0001), 0., 1.);
+        float lineD = length(p - (a + ab2 * tp));
+        float alpha = pow(1. - ablen_2 / .42, 1.4);
+
+        float spark = 0.;
+        for(int s = 0; s < 3; s++){
+          float sf = float(s);
+          float phase = fract(T * .55 + fi * .3 + sf * .333);
+          float sparkD = abs(tp - phase);
+          spark += smoothstep(.05, 0., sparkD)
+                 * smoothstep(0., .12, phase) * smoothstep(1., .88, phase);
+        }
+
+        float clickSpark = 0.;
+        if(ct < 3.){
+          float dc = min(length(nodes[i] - cp), length(nodes[j] - cp));
+          float arrived = smoothstep(0., .1, ct - dc * 1.4);
+          for(int s = 0; s < 4; s++){
+            float sf = float(s);
+            float ph = fract(ct * 1.8 - dc * .8 + sf * .25);
+            clickSpark += smoothstep(.04, 0., abs(tp - ph)) * arrived;
+          }
+          clickSpark *= exp(-ct * .9);
+        }
+
+        float lineW = .00045 / (lineD * lineD + .00004);
+        vec3 col = mix(vec3(.2, .4, 1.15), vec3(.55, .25, 1.05),
+                       fract(fi * .31 + float(j) * .77));
+        lineAccum += col * lineW * alpha * (1. + spark * 5.);
+        lineAccum += vec3(.85, .9, 1.3) * lineW * alpha * clickSpark * 3.;
+      }
+    }
+  }
+
+  c += vec3(.35, .55, 1.) * nodeGlow * .14;
+  c += vec3(.95, .9, 1.15) * pow(coreGlow, 1.) * 2.4;
+  c += lineAccum * .42;
+  c += particleGlow * .9;
+
+  float bg = fbm(p * 2.5 + t * .3);
+  c += vec3(.03, .05, .15) * bg * .6;
+
+  if(ct < 2.){
+    float dc = length(p - cp);
+    float ringT = ct * 1.3;
+    float ringW = .03 + ct * .04;
+    float ring = exp(-abs(dc - ringT) * (1. / ringW));
+    float dots = pow(abs(sin(atan(p.y - cp.y, p.x - cp.x) * 32. + T * 4.)), 25.);
+    c += vec3(.5, .7, 1.3) * ring * (.3 + dots * 1.5) * exp(-ct * 1.1);
+  }
+
+  c += vec3(.12, .18, .5) * exp(-length(p - mp) * 2.4) * .3;
+
+  c *= 1. - dot((uv - .5) * 1.3, (uv - .5) * 1.3);
+  c += grain(gl_FragCoord.xy, T);
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const SYNAPSE_CONSTELLATION = `
+#define N 10
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .14;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+  vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+  float ct = T - CT;
+
+  vec2 nodes[N];
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float ang = fi * 1.618 * TAU + sin(t + fi) * .2;
+    float rad = .18 + sqrt(fi / float(N)) * .5;
+    vec2 base = vec2(cos(ang), sin(ang)) * rad * vec2(R.x / R.y * .9, 1.);
+    base += vec2(sin(t + fi * 1.5),
+                 cos(t * .8 + fi * 1.8)) * .06;
+    vec2 toM = mp - base;
+    float md = length(toM);
+    base += toM * exp(-md * md * 1.2) * .12;
+    nodes[i] = base;
+  }
+
+  vec3 c = vec3(.005, .005, .025);
+
+  vec2 starP = p * 80.;
+  vec2 si = floor(starP);
+  float starH = h21(si);
+  if(starH > .985){
+    vec2 sf = fract(starP) - .5;
+    float sd = length(sf);
+    float tw = sin(T * 2. + starH * 100.) * .35 + .65;
+    c += vec3(.5, .6, 1.) * smoothstep(.13, 0., sd) * tw * .4;
+  }
+  vec2 starP2 = p * 200.;
+  vec2 si2 = floor(starP2);
+  float starH2 = h21(si2 + 31.7);
+  if(starH2 > .995){
+    c += vec3(.4, .5, .9) * .15;
+  }
+
+  float starGlow = 0.;
+  float crossGlow = 0.;
+  vec3 lineAccum = vec3(0.);
+
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    vec2 toN = p - nodes[i];
+    float d = length(toN);
+    float pls = sin(T * 1.2 + fi * 2.4) * .25 + .75;
+
+    starGlow += .0008 / (d * d + .00004) * pls;
+    float cross1 = exp(-abs(toN.x) * 80. - abs(toN.y) * 4.);
+    float cross2 = exp(-abs(toN.y) * 80. - abs(toN.x) * 4.);
+    crossGlow += (cross1 + cross2) * pls * .25;
+
+    vec2 ab = mp - nodes[i];
+    float ablen2 = dot(ab, ab);
+    float ablen = sqrt(ablen2);
+    if(ablen < .7){
+      float tp = clamp(dot(p - nodes[i], ab) / max(ablen2, .0001), 0., 1.);
+      float lineD = length(p - (nodes[i] + ab * tp));
+      float alpha = pow(1. - ablen / .7, 1.6);
+      float lineW = .0004 / (lineD * lineD + .00004);
+      vec3 col = mix(vec3(.4, .6, 1.2), vec3(.7, .4, 1.2), fract(fi * .41));
+      lineAccum += col * lineW * alpha;
+    }
+
+    for(int j = i + 1; j < N; j++){
+      vec2 a = nodes[i];
+      vec2 ab2 = nodes[j] - a;
+      float ablen2_2 = dot(ab2, ab2);
+      float ablen_2 = sqrt(ablen2_2);
+      if(ablen_2 < .5){
+        float tp = clamp(dot(p - a, ab2) / max(ablen2_2, .0001), 0., 1.);
+        float lineD = length(p - (a + ab2 * tp));
+        float alpha = pow(1. - ablen_2 / .5, 1.5);
+        float lineW = .00035 / (lineD * lineD + .00004);
+        vec3 col = mix(vec3(.18, .35, 1.), vec3(.5, .2, 1.),
+                       fract(fi * .31 + float(j) * .77));
+        lineAccum += col * lineW * alpha * .85;
+      }
+    }
+  }
+
+  if(ct < 1.5){
+    float minD = 100.;
+    int nearI = 0;
+    for(int i = 0; i < N; i++){
+      float dN = length(nodes[i] - cp);
+      if(dN < minD){ minD = dN; nearI = i; }
+    }
+    vec2 segA = cp;
+    vec2 segB = nodes[nearI];
+    vec2 ab = segB - segA;
+    float ablen = length(ab) + .0001;
+    float tp = clamp(dot(p - segA, ab) / dot(ab, ab), 0., 1.);
+    vec2 along = segA + ab * tp;
+    vec2 perp = vec2(-ab.y, ab.x) / ablen;
+    float jit = (fbm(vec2(tp * 12., T * 3.)) - .5) * .03
+              + (fbm(vec2(tp * 40., T * 5.)) - .5) * .012;
+    vec2 closest = along + perp * jit;
+    float lineD = length(p - closest);
+    float boltFade = exp(-ct * 2.5) * smoothstep(1.5, 0., ct);
+    c += vec3(.7, .9, 1.6) * exp(-lineD * 90.) * boltFade;
+    c += vec3(.3, .45, 1.1) * exp(-lineD * 22.) * boltFade * .35;
+
+    float burstX = exp(-abs(p.x - cp.x) * 55. - abs(p.y - cp.y) * 4.);
+    float burstY = exp(-abs(p.y - cp.y) * 55. - abs(p.x - cp.x) * 4.);
+    float burstDiag1 = exp(-abs((p.x - cp.x) + (p.y - cp.y)) * 55. - abs((p.x - cp.x) - (p.y - cp.y)) * 5.);
+    float burstDiag2 = exp(-abs((p.x - cp.x) - (p.y - cp.y)) * 55. - abs((p.x - cp.x) + (p.y - cp.y)) * 5.);
+    c += vec3(.75, .85, 1.5) * (burstX + burstY) * exp(-ct * 2.5);
+    c += vec3(.4, .55, 1.2) * (burstDiag1 + burstDiag2) * exp(-ct * 2.5) * .6;
+    float cd = length(p - cp);
+    c += vec3(.3, .4, 1.) * exp(-cd * cd * 28.) * exp(-ct * 2.) * .8;
+
+    float strikeD = length(p - segB);
+    c += vec3(.6, .8, 1.5) * exp(-strikeD * strikeD * 250.) * boltFade * 1.5;
+  }
+
+  c += vec3(.45, .6, 1.15) * starGlow * .22;
+  c += vec3(.95, .95, 1.15) * pow(starGlow * .14, 1.5) * 2.;
+  c += vec3(.55, .7, 1.2) * crossGlow * .3;
+  c += lineAccum * .4;
+
+  float bg = fbm(p * 1.5 + t * .2);
+  c += vec3(.02, .015, .06) * bg * .8;
+  c += vec3(.025, .01, .05) * pow(fbm(p * .8 - t * .1), 2.) * 1.2;
+
+  c += vec3(.08, .12, .4) * exp(-length(p - mp) * 2.5) * .25;
+
+  c *= 1. - dot((uv - .5) * 1.3, (uv - .5) * 1.3);
+  c += grain(gl_FragCoord.xy, T);
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const SYNAPSE_VAPOR = `
+#define N 10
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .14;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+  vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+  float ct = T - CT;
+
+  vec2 nodes[N];
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float ang = fi * 1.618 * TAU + sin(t + fi) * .2;
+    float rad = .18 + sqrt(fi / float(N)) * .5;
+    vec2 base = vec2(cos(ang), sin(ang)) * rad * vec2(R.x / R.y * .9, 1.);
+    base += vec2(sin(t + fi * 1.5),
+                 cos(t * .8 + fi * 1.8)) * .06;
+    vec2 toM = mp - base;
+    float md = length(toM);
+    base += toM * exp(-md * md * 1.2) * .12;
+    nodes[i] = base;
+  }
+
+  vec3 c = vec3(.006, .003, .025);
+
+  vec2 starP = p * 80.;
+  vec2 si = floor(starP);
+  float starH = h21(si);
+  if(starH > .985){
+    vec2 sf = fract(starP) - .5;
+    float sd = length(sf);
+    float tw = sin(T * 2. + starH * 100.) * .35 + .65;
+    vec3 starCol = mix(vec3(0., .9, 1.1), vec3(1., .25, .9), step(.5, starH));
+    c += starCol * smoothstep(.13, 0., sd) * tw * .4;
+  }
+  vec2 starP2 = p * 200.;
+  vec2 si2 = floor(starP2);
+  float starH2 = h21(si2 + 31.7);
+  if(starH2 > .995){
+    c += vec3(.5, .25, .85) * .15;
+  }
+
+  float starGlow = 0.;
+  vec3 starColAcc = vec3(0.);
+  vec3 lineAccum = vec3(0.);
+
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    vec2 toN = p - nodes[i];
+    float d = length(toN);
+    float pls = sin(T * 1.2 + fi * 2.4) * .25 + .75;
+
+    starGlow += .0008 / (d * d + .00004) * pls;
+    float cross1 = exp(-abs(toN.x) * 80. - abs(toN.y) * 4.);
+    float cross2 = exp(-abs(toN.y) * 80. - abs(toN.x) * 4.);
+
+    float nh = fract(fi * .41);
+    vec3 nodeCol;
+    if(nh < .34) nodeCol = vec3(0., .95, 1.15);
+    else if(nh < .67) nodeCol = vec3(1., .2, .85);
+    else nodeCol = vec3(.5, .25, 1.15);
+    starColAcc += nodeCol * (.0008 / (d * d + .00004)) * pls;
+    starColAcc += nodeCol * (cross1 + cross2) * pls * .32;
+
+    vec2 ab = mp - nodes[i];
+    float ablen2 = dot(ab, ab);
+    float ablen = sqrt(ablen2);
+    if(ablen < .7){
+      float tp = clamp(dot(p - nodes[i], ab) / max(ablen2, .0001), 0., 1.);
+      float lineD = length(p - (nodes[i] + ab * tp));
+      float alpha = pow(1. - ablen / .7, 1.6);
+      float lineW = .0004 / (lineD * lineD + .00004);
+      vec3 col = mix(vec3(0., .85, 1.1), vec3(1., .18, .85), fract(fi * .41));
+      lineAccum += col * lineW * alpha * 1.2;
+    }
+
+    for(int j = i + 1; j < N; j++){
+      vec2 a = nodes[i];
+      vec2 ab2 = nodes[j] - a;
+      float ablen2_2 = dot(ab2, ab2);
+      float ablen_2 = sqrt(ablen2_2);
+      if(ablen_2 < .5){
+        float tp = clamp(dot(p - a, ab2) / max(ablen2_2, .0001), 0., 1.);
+        float lineD = length(p - (a + ab2 * tp));
+        float alpha = pow(1. - ablen_2 / .5, 1.5);
+        float lineW = .00035 / (lineD * lineD + .00004);
+        float pal = fract(fi * .31 + float(j) * .77);
+        vec3 col;
+        if(pal < .34) col = vec3(0., .9, 1.1);
+        else if(pal < .67) col = vec3(1., .15, .8);
+        else col = vec3(.45, .2, 1.1);
+        lineAccum += col * lineW * alpha * .85;
+      }
+    }
+  }
+
+  if(ct < 1.5){
+    float minD = 100.;
+    int nearI = 0;
+    for(int i = 0; i < N; i++){
+      float dN = length(nodes[i] - cp);
+      if(dN < minD){ minD = dN; nearI = i; }
+    }
+    vec2 segA = cp;
+    vec2 segB = nodes[nearI];
+    vec2 ab = segB - segA;
+    float ablen = length(ab) + .0001;
+    float tp = clamp(dot(p - segA, ab) / dot(ab, ab), 0., 1.);
+    vec2 along = segA + ab * tp;
+    vec2 perp = vec2(-ab.y, ab.x) / ablen;
+    float jit = (fbm(vec2(tp * 12., T * 3.)) - .5) * .03
+              + (fbm(vec2(tp * 40., T * 5.)) - .5) * .012;
+    vec2 closest = along + perp * jit;
+    float lineD = length(p - closest);
+    float boltFade = exp(-ct * 2.5) * smoothstep(1.5, 0., ct);
+    float lineDcyan = length(p - (closest - perp * .004));
+    float lineDpink = length(p - (closest + perp * .004));
+    c += vec3(0., .95, 1.2) * exp(-lineDcyan * 90.) * boltFade;
+    c += vec3(1., .2, .9) * exp(-lineDpink * 90.) * boltFade;
+    c += vec3(.5, .3, 1.) * exp(-lineD * 22.) * boltFade * .4;
+
+    float burstX = exp(-abs(p.x - cp.x) * 55. - abs(p.y - cp.y) * 4.);
+    float burstY = exp(-abs(p.y - cp.y) * 55. - abs(p.x - cp.x) * 4.);
+    float burstDiag1 = exp(-abs((p.x - cp.x) + (p.y - cp.y)) * 55. - abs((p.x - cp.x) - (p.y - cp.y)) * 5.);
+    float burstDiag2 = exp(-abs((p.x - cp.x) - (p.y - cp.y)) * 55. - abs((p.x - cp.x) + (p.y - cp.y)) * 5.);
+    c += vec3(0., .9, 1.2) * (burstX + burstY) * exp(-ct * 2.5);
+    c += vec3(1., .3, .9) * (burstDiag1 + burstDiag2) * exp(-ct * 2.5) * .85;
+    float cd = length(p - cp);
+    c += vec3(.5, .2, 1.) * exp(-cd * cd * 28.) * exp(-ct * 2.) * .9;
+
+    float strikeD = length(p - segB);
+    c += vec3(.2, .85, 1.3) * exp(-strikeD * strikeD * 250.) * boltFade * 1.4;
+  }
+
+  c += starColAcc * .22;
+  c += vec3(1., .95, 1.1) * pow(starGlow * .14, 1.5) * 1.6;
+  c += lineAccum * .4;
+
+  float bg = fbm(p * 1.5 + t * .2);
+  c += vec3(.04, .006, .06) * bg * .8;
+  c += vec3(.005, .02, .055) * pow(fbm(p * .8 - t * .1), 2.) * 1.2;
+
+  c += vec3(.4, .08, .7) * exp(-length(p - mp) * 2.5) * .3;
+  c += vec3(.05, .45, .65) * exp(-length(p - mp) * 5.5) * .25;
+
+  c *= .93 + .07 * sin(gl_FragCoord.y * 1.6);
+
+  c *= 1. - dot((uv - .5) * 1.3, (uv - .5) * 1.3);
+  c += grain(gl_FragCoord.xy, T);
+  O = vec4(max(c, 0.), 1.);
+}`;
+
+  const SYNAPSE_VAPOR_DRIVE = `
+#define N 10
+void main(){
+  vec2 uv = gl_FragCoord.xy / R;
+  vec2 p = (gl_FragCoord.xy - R * .5) / R.y;
+  float t = T * .14;
+
+  vec2 mp = (M - .5) * vec2(R.x / R.y, 1.);
+  vec2 cp = (C - .5) * vec2(R.x / R.y, 1.);
+  float ct = T - CT;
+
+  vec2 nodes[N];
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    float ang = fi * 1.618 * TAU + sin(t + fi) * .2;
+    float rad = .18 + sqrt(fi / float(N)) * .5;
+    vec2 base = vec2(cos(ang), sin(ang)) * rad * vec2(R.x / R.y * .9, 1.);
+    base += vec2(sin(t + fi * 1.5),
+                 cos(t * .8 + fi * 1.8)) * .06;
+    vec2 toM = mp - base;
+    float md = length(toM);
+    base += toM * exp(-md * md * 1.2) * .12;
+    nodes[i] = base;
+  }
+
+  vec3 c = vec3(0.);
+  float ambient = .1;
+
+  vec2 starP = p * 80.;
+  vec2 si = floor(starP);
+  float starH = h21(si);
+  if(starH > .985){
+    vec2 sf = fract(starP) - .5;
+    float sd = length(sf);
+    float tw = sin(T * 2. + starH * 100.) * .35 + .65;
+    vec3 starCol = mix(vec3(0., .9, 1.1), vec3(1., .25, .9), step(.5, starH));
+    c += starCol * smoothstep(.13, 0., sd) * tw * .55;
+  }
+
+  float starGlow = 0.;
+  vec3 starColAcc = vec3(0.);
+  vec3 lineAccum = vec3(0.);
+
+  for(int i = 0; i < N; i++){
+    float fi = float(i);
+    vec2 toN = p - nodes[i];
+    float d = length(toN);
+    float pls = sin(T * 1.2 + fi * 2.4) * .25 + .75;
+
+    starGlow += .001 / (d * d + .00004) * pls;
+    float cross1 = exp(-abs(toN.x) * 80. - abs(toN.y) * 4.);
+    float cross2 = exp(-abs(toN.y) * 80. - abs(toN.x) * 4.);
+
+    float nh = fract(fi * .41);
+    vec3 nodeCol;
+    if(nh < .34) nodeCol = vec3(0., .95, 1.15);
+    else if(nh < .67) nodeCol = vec3(1., .2, .85);
+    else nodeCol = vec3(.55, .25, 1.15);
+    starColAcc += nodeCol * (.001 / (d * d + .00004)) * pls;
+    starColAcc += nodeCol * (cross1 + cross2) * pls * .4;
+
+    vec2 ab = mp - nodes[i];
+    float ablen2 = dot(ab, ab);
+    float ablen = sqrt(ablen2);
+    if(ablen < .7){
+      float tp = clamp(dot(p - nodes[i], ab) / max(ablen2, .0001), 0., 1.);
+      float lineD = length(p - (nodes[i] + ab * tp));
+      float alpha2 = pow(1. - ablen / .7, 1.6);
+      float lineW = .0005 / (lineD * lineD + .00004);
+      vec3 col = mix(vec3(0., .85, 1.1), vec3(1., .18, .85), fract(fi * .41));
+      lineAccum += col * lineW * alpha2 * 1.4;
+    }
+
+    for(int j = i + 1; j < N; j++){
+      vec2 a = nodes[i];
+      vec2 ab2 = nodes[j] - a;
+      float ablen2_2 = dot(ab2, ab2);
+      float ablen_2 = sqrt(ablen2_2);
+      if(ablen_2 < .5){
+        float tp = clamp(dot(p - a, ab2) / max(ablen2_2, .0001), 0., 1.);
+        float lineD = length(p - (a + ab2 * tp));
+        float alpha2 = pow(1. - ablen_2 / .5, 1.5);
+        float lineW = .00045 / (lineD * lineD + .00004);
+        float pal = fract(fi * .31 + float(j) * .77);
+        vec3 col;
+        if(pal < .34) col = vec3(0., .9, 1.1);
+        else if(pal < .67) col = vec3(1., .15, .8);
+        else col = vec3(.45, .2, 1.1);
+        lineAccum += col * lineW * alpha2 * 1.;
+      }
+    }
+  }
+
+  if(ct < 1.5){
+    float minD = 100.;
+    int nearI = 0;
+    for(int i = 0; i < N; i++){
+      float dN = length(nodes[i] - cp);
+      if(dN < minD){ minD = dN; nearI = i; }
+    }
+    vec2 segA = cp;
+    vec2 segB = nodes[nearI];
+    vec2 ab = segB - segA;
+    float ablen = length(ab) + .0001;
+    float tp = clamp(dot(p - segA, ab) / dot(ab, ab), 0., 1.);
+    vec2 along = segA + ab * tp;
+    vec2 perp = vec2(-ab.y, ab.x) / ablen;
+    float jit = (fbm(vec2(tp * 12., T * 3.)) - .5) * .03
+              + (fbm(vec2(tp * 40., T * 5.)) - .5) * .012;
+    vec2 closest = along + perp * jit;
+    float lineD = length(p - closest);
+    float boltFade = exp(-ct * 2.5) * smoothstep(1.5, 0., ct);
+    float lineDcyan = length(p - (closest - perp * .004));
+    float lineDpink = length(p - (closest + perp * .004));
+    c += vec3(0., .95, 1.2) * exp(-lineDcyan * 90.) * boltFade;
+    c += vec3(1., .2, .9) * exp(-lineDpink * 90.) * boltFade;
+    c += vec3(.5, .3, 1.) * exp(-lineD * 22.) * boltFade * .5;
+
+    float burstX = exp(-abs(p.x - cp.x) * 55. - abs(p.y - cp.y) * 4.);
+    float burstY = exp(-abs(p.y - cp.y) * 55. - abs(p.x - cp.x) * 4.);
+    float burstDiag1 = exp(-abs((p.x - cp.x) + (p.y - cp.y)) * 55. - abs((p.x - cp.x) - (p.y - cp.y)) * 5.);
+    float burstDiag2 = exp(-abs((p.x - cp.x) - (p.y - cp.y)) * 55. - abs((p.x - cp.x) + (p.y - cp.y)) * 5.);
+    c += vec3(0., .9, 1.2) * (burstX + burstY) * exp(-ct * 2.5) * 1.2;
+    c += vec3(1., .3, .9) * (burstDiag1 + burstDiag2) * exp(-ct * 2.5) * 1.;
+    float cd = length(p - cp);
+    c += vec3(.5, .2, 1.) * exp(-cd * cd * 28.) * exp(-ct * 2.) * 1.;
+
+    float strikeD = length(p - segB);
+    c += vec3(.2, .85, 1.3) * exp(-strikeD * strikeD * 250.) * boltFade * 1.6;
+  }
+
+  c += starColAcc * .3;
+  c += vec3(1., .95, 1.1) * pow(starGlow * .14, 1.5) * 1.8;
+  c += lineAccum * .5;
+
+  c += vec3(.4, .08, .7) * exp(-length(p - mp) * 2.5) * .4;
+  c += vec3(.05, .45, .65) * exp(-length(p - mp) * 5.5) * .35;
+
+  c *= .92 + .08 * sin(gl_FragCoord.y * 1.6);
+
+  float vig = dot((uv - .5) * 1.4, (uv - .5) * 1.4);
+  float lum = dot(c, vec3(.299, .587, .114));
+  float alpha = clamp(ambient + pow(lum * 1.4, .65) + vig * .65, 0., 1.);
+  c += vec3(.015, .005, .04) * vig * 2.5;
+
+  c += grain(gl_FragCoord.xy, T) * .8;
+  O = vec4(max(c, 0.), alpha);
+}`;
+
+  const DEFAULT_DRIVE_VIDEO = 'https://cdn.shopify.com/videos/c/o/v/39ce99635f904af785d3e41ac326bcc7.mp4';
+
+  const SHADERS = {
+    nebula:        { source: NEBULA,                hasAlpha: false },
+    horizon:       { source: HORIZON,               hasAlpha: false },
+    voronoi:       { source: VORONOI,               hasAlpha: false },
+    synapse:       { source: SYNAPSE,               hasAlpha: false },
+    noir:          { source: SYNAPSE_NOIR,          hasAlpha: false },
+    bloom:         { source: SYNAPSE_BLOOM,         hasAlpha: false },
+    constellation: { source: SYNAPSE_CONSTELLATION, hasAlpha: false },
+    vapor:         { source: SYNAPSE_VAPOR,         hasAlpha: false },
+    drive:         { source: SYNAPSE_VAPOR_DRIVE,   hasAlpha: true, needsVideo: true },
+  };
+
+  window.OmniflexInteractiveWallpapers = { VERT, COMMON, SHADERS, DEFAULT_DRIVE_VIDEO };
+})();

--- a/sections/interactive-wallpaper-banner.liquid
+++ b/sections/interactive-wallpaper-banner.liquid
@@ -20,6 +20,7 @@
     assign video_url = 'https://cdn.shopify.com/videos/c/o/v/39ce99635f904af785d3e41ac326bcc7.mp4'
   endif
   assign extend = section.settings.extend_behind_header
+  assign persist_transparent = section.settings.persist_transparent_header
 -%}
 
 <style>
@@ -159,6 +160,7 @@
   id="InteractiveWallpaperBanner-{{ section.id }}"
   class="interactive-wallpaper-banner color-{{ section.settings.color_scheme }} iwb iwb--pos-{{ section.settings.desktop_content_position }} iwb--align-{{ section.settings.desktop_content_alignment }} iwb--align-mobile-{{ section.settings.mobile_content_alignment }}{% unless section.settings.show_text_box %} iwb--no-box{% endunless %}{% if extend %} iwb--behind-header{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
   data-variant="{{ variant }}"
+  {% if persist_transparent %}data-persist-transparent-header="true"{% endif %}
 >
   {%- if needs_video -%}
     <video
@@ -400,15 +402,26 @@
       // strip. Each instance writes its own overlap state to a data attribute
       // so multiple banners on one page can coexist without fighting over
       // body.iwb-header-transparent.
+      //
+      // If data-persist-transparent-header is set, this section keeps the
+      // header transparent for the rest of the page (the data attribute is
+      // pinned to "true" so the body class stays applied past the banner).
+      var persistTransparent = root.dataset.persistTransparentHeader === 'true';
       var syncHeaderTransparency = null;
       if (behindHeader) {
+        if (persistTransparent) {
+          root.dataset.iwbOverlapsHeader = 'true';
+          document.body.classList.add('iwb-header-transparent');
+        }
         var rafThrottle = false;
         function _sync() {
           rafThrottle = false;
-          var rect = root.getBoundingClientRect();
-          var headerH = getHeaderHeight() || 80;
-          var overlaps = rect.top < headerH && rect.bottom > 0;
-          root.dataset.iwbOverlapsHeader = overlaps ? 'true' : 'false';
+          if (!persistTransparent) {
+            var rect = root.getBoundingClientRect();
+            var headerH = getHeaderHeight() || 80;
+            var overlaps = rect.top < headerH && rect.bottom > 0;
+            root.dataset.iwbOverlapsHeader = overlaps ? 'true' : 'false';
+          }
           var anyOverlap = !!document.querySelector('[data-iwb-overlaps-header="true"]');
           document.body.classList.toggle('iwb-header-transparent', anyOverlap);
         }
@@ -558,6 +571,13 @@
       "label": "Extend behind site header",
       "default": true,
       "info": "Pulls the banner up so its background fills the area behind the header. The header becomes transparent over this section."
+    },
+    {
+      "type": "checkbox",
+      "id": "persist_transparent_header",
+      "label": "Keep header transparent on the rest of the page",
+      "default": false,
+      "info": "When on, the site header stays transparent after you scroll past the banner — content below the banner shows through it. Otherwise the header reverts to its normal background once the banner has fully scrolled away."
     },
     {
       "type": "header",

--- a/sections/interactive-wallpaper-banner.liquid
+++ b/sections/interactive-wallpaper-banner.liquid
@@ -577,7 +577,7 @@
       "id": "persist_transparent_header",
       "label": "Keep header transparent on the rest of the page",
       "default": false,
-      "info": "When on, the site header stays transparent after you scroll past the banner — content below the banner shows through it. Otherwise the header reverts to its normal background once the banner has fully scrolled away."
+      "info": "When on, the site header stays transparent after you scroll past the banner - content below the banner shows through it. Otherwise the header reverts to its normal background once the banner has fully scrolled away."
     },
     {
       "type": "header",

--- a/sections/interactive-wallpaper-banner.liquid
+++ b/sections/interactive-wallpaper-banner.liquid
@@ -1,0 +1,679 @@
+{%- comment -%}
+  Interactive Wallpaper Banner
+
+  Renders one of nine WebGL "wallpapers" as a full-bleed banner background
+  with overlay heading / subheading / description / button blocks. When
+  "Extend behind site header" is on, the section's media reaches past the
+  fixed header (the header background becomes transparent over this section).
+{%- endcomment -%}
+
+<script src="{{ 'interactive-wallpaper-shaders.js' | asset_url }}"></script>
+
+{%- liquid
+  assign variant = section.settings.wallpaper_variant
+  assign needs_video = false
+  if variant == 'drive'
+    assign needs_video = true
+  endif
+  assign video_url = section.settings.video_url
+  if video_url == blank
+    assign video_url = 'https://cdn.shopify.com/videos/c/o/v/39ce99635f904af785d3e41ac326bcc7.mp4'
+  endif
+  assign extend = section.settings.extend_behind_header
+-%}
+
+<style>
+  #InteractiveWallpaperBanner-{{ section.id }} {
+    --iwb-height: {{ section.settings.section_height }}vh;
+    --iwb-overlay-opacity: {{ section.settings.image_overlay_opacity | divided_by: 100.0 }};
+    position: relative;
+    width: 100%;
+    min-height: var(--iwb-height);
+    background: #06061a;
+    overflow: hidden;
+    isolation: isolate;
+    color: #fff;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--behind-header {
+    margin-top: calc(-1 * var(--iwb-header-offset, var(--header-height, 8rem)));
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__canvas,
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__video {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    pointer-events: none;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__video {
+    object-fit: cover;
+    z-index: 0;
+    filter: brightness(.55) contrast(1.15) saturate(.55) hue-rotate(-15deg);
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__canvas {
+    z-index: 1;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__interaction {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    cursor: crosshair;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__overlay {
+    position: absolute;
+    inset: 0;
+    background: #000;
+    opacity: var(--iwb-overlay-opacity);
+    pointer-events: none;
+    z-index: 3;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__content {
+    position: relative;
+    z-index: 4;
+    min-height: var(--iwb-height);
+    padding: 4rem 2rem;
+    display: flex;
+    flex-direction: column;
+    pointer-events: none;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--behind-header .iwb__content {
+    padding-top: calc(var(--iwb-header-offset, var(--header-height, 8rem)) + 4rem);
+  }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--pos-top    .iwb__content { justify-content: flex-start; }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--pos-middle .iwb__content { justify-content: center; }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--pos-bottom .iwb__content { justify-content: flex-end; }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-left   .iwb__content { align-items: flex-start; text-align: left; }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-center .iwb__content { align-items: center;     text-align: center; }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-right  .iwb__content { align-items: flex-end;   text-align: right; }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__box {
+    max-width: 70rem;
+    padding: 2rem 2.5rem;
+    border-radius: 1rem;
+    pointer-events: auto;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--no-box .iwb__box {
+    padding: 0;
+    background: transparent !important;
+    border: 0 !important;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__subheading {
+    display: block;
+    font-size: 1.2rem;
+    letter-spacing: .35em;
+    text-transform: uppercase;
+    color: rgba(150, 200, 255, .8);
+    margin: 0 0 1rem;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__heading {
+    font-weight: 200;
+    letter-spacing: .04em;
+    margin: 0 0 1.4rem;
+    color: rgba(230, 235, 255, .98);
+    text-shadow: 0 0 40px rgba(120, 100, 255, .45), 0 0 80px rgba(255, 50, 180, .2);
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__description {
+    font-size: clamp(1.1rem, 1.4vw, 1.35rem);
+    line-height: 1.55;
+    color: rgba(220, 230, 255, .85);
+    margin: 0 0 1.8rem;
+    max-width: 60rem;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }} .iwb__buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: inherit;
+  }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-center .iwb__buttons { justify-content: center; }
+  #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-right  .iwb__buttons { justify-content: flex-end; }
+
+  @media screen and (max-width: 749px) {
+    #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-mobile-left   .iwb__content { align-items: flex-start; text-align: left; }
+    #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-mobile-center .iwb__content { align-items: center;     text-align: center; }
+    #InteractiveWallpaperBanner-{{ section.id }}.iwb--align-mobile-right  .iwb__content { align-items: flex-end;   text-align: right; }
+    #InteractiveWallpaperBanner-{{ section.id }} .iwb__box { padding: 1.5rem; }
+  }
+</style>
+
+{%- if extend -%}
+<style>
+  body.iwb-header-transparent .section-header,
+  body.iwb-header-transparent .section-header .header-wrapper,
+  body.iwb-header-transparent .section-header .header-wrapper.gradient,
+  body.iwb-header-transparent .shopify-section-group-header-group {
+    background: transparent !important;
+    background-color: transparent !important;
+    background-image: none !important;
+  }
+  body.iwb-header-transparent .header-wrapper--border-bottom {
+    border-bottom-color: transparent !important;
+  }
+  body.iwb-header-transparent .section-header {
+    position: relative;
+    z-index: 4;
+  }
+</style>
+{%- endif -%}
+
+<div
+  id="InteractiveWallpaperBanner-{{ section.id }}"
+  class="interactive-wallpaper-banner color-{{ section.settings.color_scheme }} iwb iwb--pos-{{ section.settings.desktop_content_position }} iwb--align-{{ section.settings.desktop_content_alignment }} iwb--align-mobile-{{ section.settings.mobile_content_alignment }}{% unless section.settings.show_text_box %} iwb--no-box{% endunless %}{% if extend %} iwb--behind-header{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
+  data-variant="{{ variant }}"
+  {% if needs_video %}data-video-url="{{ video_url }}"{% endif %}
+>
+  {%- if needs_video -%}
+    <video
+      class="iwb__video"
+      src="{{ video_url }}"
+      muted
+      loop
+      playsinline
+      autoplay
+      preload="auto"
+      aria-hidden="true"
+    ></video>
+  {%- endif -%}
+  <canvas class="iwb__canvas" aria-hidden="true"></canvas>
+  <div class="iwb__interaction" aria-hidden="true"></div>
+  <div class="iwb__overlay" aria-hidden="true"></div>
+
+  <div class="iwb__content page-width">
+    <div class="iwb__box{% if section.settings.show_text_box %} content-container content-container--full-width-mobile color-{{ section.settings.color_scheme }} gradient{% endif %}">
+      {%- for block in section.blocks -%}
+        {%- case block.type -%}
+          {%- when 'subheading' -%}
+            <span class="iwb__subheading caption-with-letter-spacing" {{ block.shopify_attributes }}>
+              {{- block.settings.subheading -}}
+            </span>
+          {%- when 'heading' -%}
+            <h2
+              class="iwb__heading inline-richtext {{ block.settings.heading_size }}"
+              {{ block.shopify_attributes }}
+            >
+              {{ block.settings.heading }}
+            </h2>
+          {%- when 'text' -%}
+            <div class="iwb__description rte" {{ block.shopify_attributes }}>
+              {{ block.settings.text }}
+            </div>
+          {%- when 'buttons' -%}
+            <div class="iwb__buttons" {{ block.shopify_attributes }}>
+              {%- if block.settings.button_label_1 != blank -%}
+                <a
+                  {% if block.settings.button_link_1 == blank %}
+                    role="link" aria-disabled="true"
+                  {% else %}
+                    href="{{ block.settings.button_link_1 }}"
+                  {% endif %}
+                  class="button{% if block.settings.button_style_secondary_1 %} button--secondary{% else %} button--primary{% endif %}"
+                >
+                  {{- block.settings.button_label_1 | escape -}}
+                </a>
+              {%- endif -%}
+              {%- if block.settings.button_label_2 != blank -%}
+                <a
+                  {% if block.settings.button_link_2 == blank %}
+                    role="link" aria-disabled="true"
+                  {% else %}
+                    href="{{ block.settings.button_link_2 }}"
+                  {% endif %}
+                  class="button{% if block.settings.button_style_secondary_2 %} button--secondary{% else %} button--primary{% endif %}"
+                >
+                  {{- block.settings.button_label_2 | escape -}}
+                </a>
+              {%- endif -%}
+            </div>
+        {%- endcase -%}
+      {%- endfor -%}
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var root = document.getElementById('InteractiveWallpaperBanner-{{ section.id }}');
+    if (!root) return;
+
+    if (!window.OmniflexInteractiveWallpapers) {
+      console.error('[interactive-wallpaper-banner] shader library failed to load');
+      return;
+    }
+    init(window.OmniflexInteractiveWallpapers);
+
+    function init(L) {
+      var variantKey = (root.getAttribute('data-variant') || 'vapor').toLowerCase();
+      var variant = L.SHADERS[variantKey] || L.SHADERS.vapor;
+      var canvas = root.querySelector('.iwb__canvas');
+      var interaction = root.querySelector('.iwb__interaction');
+      var video = root.querySelector('.iwb__video');
+
+      var gl = canvas.getContext('webgl2', {
+        antialias: false,
+        alpha: !!variant.hasAlpha,
+        premultipliedAlpha: false,
+      });
+      if (!gl) {
+        root.style.background = 'linear-gradient(135deg,#0a0524,#1a0a3d,#0a0524)';
+        return;
+      }
+
+      if (video) {
+        var pl = video.play && video.play();
+        if (pl && pl.catch) pl.catch(function () {});
+      }
+
+      function compile(type, src) {
+        var s = gl.createShader(type);
+        gl.shaderSource(s, src);
+        gl.compileShader(s);
+        if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+          console.error('[interactive-wallpaper-banner] shader compile:\n' + gl.getShaderInfoLog(s));
+        }
+        return s;
+      }
+      var prog = gl.createProgram();
+      gl.attachShader(prog, compile(gl.VERTEX_SHADER, L.VERT));
+      gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, L.COMMON + variant.source));
+      gl.linkProgram(prog);
+      if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+        console.error('[interactive-wallpaper-banner] link:\n' + gl.getProgramInfoLog(prog));
+        return;
+      }
+
+      var vao = gl.createVertexArray();
+      gl.bindVertexArray(vao);
+      var buf = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gl.STATIC_DRAW);
+      gl.enableVertexAttribArray(0);
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+      var uR  = gl.getUniformLocation(prog, 'R');
+      var uT  = gl.getUniformLocation(prog, 'T');
+      var uM  = gl.getUniformLocation(prog, 'M');
+      var uC  = gl.getUniformLocation(prog, 'C');
+      var uCT = gl.getUniformLocation(prog, 'CT');
+
+      var mouse  = [0.5, 0.5];
+      var smooth = [0.5, 0.5];
+      var click  = [0.5, 0.5];
+      var clickT = -100;
+      var t0 = performance.now() / 1000;
+
+      function resize() {
+        var dpr = Math.min(window.devicePixelRatio || 1, 2);
+        var w = canvas.clientWidth || root.clientWidth;
+        var h = canvas.clientHeight || root.clientHeight;
+        canvas.width  = Math.max(2, Math.floor(w * dpr));
+        canvas.height = Math.max(2, Math.floor(h * dpr));
+        gl.viewport(0, 0, canvas.width, canvas.height);
+      }
+      resize();
+      if (window.ResizeObserver) {
+        new ResizeObserver(resize).observe(canvas);
+      } else {
+        window.addEventListener('resize', resize);
+      }
+
+      // Track mouse anywhere over the banner; clicks fire effects unless the
+      // pointer is over an interactive element (button/link).
+      function setMouseFromEvent(e) {
+        var r = canvas.getBoundingClientRect();
+        mouse[0] = (e.clientX - r.left) / r.width;
+        mouse[1] = 1 - (e.clientY - r.top) / r.height;
+      }
+      function setClickFromEvent(e) {
+        var r = canvas.getBoundingClientRect();
+        click[0] = (e.clientX - r.left) / r.width;
+        click[1] = 1 - (e.clientY - r.top) / r.height;
+        clickT = performance.now() / 1000 - t0;
+      }
+
+      root.addEventListener('mousemove', setMouseFromEvent);
+      root.addEventListener('click', setClickFromEvent);
+      root.addEventListener('mouseleave', function () { mouse[0] = 0.5; mouse[1] = 0.5; });
+      root.addEventListener('touchmove', function (e) {
+        if (!e.touches[0]) return;
+        setMouseFromEvent(e.touches[0]);
+      }, { passive: true });
+      root.addEventListener('touchstart', function (e) {
+        if (!e.touches[0]) return;
+        setClickFromEvent(e.touches[0]);
+      }, { passive: true });
+
+      // Header extension — measure how far our section sits below the top of
+      // the page (i.e. the cumulative header-group height) and expose it as
+      // a CSS variable so the banner can pull itself up under the header.
+      var behindHeader = root.classList.contains('iwb--behind-header');
+      function getHeaderHeight() {
+        var total = 0;
+        document.querySelectorAll('.shopify-section-group-header-group').forEach(function (el) {
+          if (el.contains(root)) return;
+          total += el.getBoundingClientRect().height;
+        });
+        return total;
+      }
+      function updateHeaderOffset() {
+        if (!behindHeader) {
+          root.style.setProperty('--iwb-header-offset', '0px');
+          return;
+        }
+        var h = getHeaderHeight();
+        if (h === 0) {
+          // Initial render before header element is measured: estimate from
+          // the section's current top offset.
+          var rect = root.getBoundingClientRect();
+          h = rect.top + window.scrollY + parseFloat(getComputedStyle(root).marginTop || '0');
+        }
+        root.style.setProperty('--iwb-header-offset', h + 'px');
+      }
+      updateHeaderOffset();
+      window.addEventListener('load', updateHeaderOffset);
+      window.addEventListener('resize', updateHeaderOffset);
+      setTimeout(updateHeaderOffset, 50);
+      setTimeout(updateHeaderOffset, 500);
+
+      // Toggle a body class while the wallpaper section overlaps the header
+      // strip, so the header background becomes transparent only when the
+      // wallpaper is actually behind it.
+      if (behindHeader) {
+        var transparent = false;
+        function syncHeaderTransparency() {
+          var rect = root.getBoundingClientRect();
+          var headerH = getHeaderHeight() || 80;
+          var overlaps = rect.top < headerH && rect.bottom > 0;
+          if (overlaps && !transparent) {
+            document.body.classList.add('iwb-header-transparent');
+            transparent = true;
+          } else if (!overlaps && transparent) {
+            document.body.classList.remove('iwb-header-transparent');
+            transparent = false;
+          }
+        }
+        syncHeaderTransparency();
+        window.addEventListener('scroll', syncHeaderTransparency, { passive: true });
+        window.addEventListener('resize', syncHeaderTransparency);
+        setTimeout(syncHeaderTransparency, 100);
+      }
+
+      var rafId = null;
+      var visible = true;
+      function frame() {
+        if (!visible) { rafId = null; return; }
+        var t = performance.now() / 1000 - t0;
+        smooth[0] += (mouse[0] - smooth[0]) * 0.07;
+        smooth[1] += (mouse[1] - smooth[1]) * 0.07;
+        if (variant.hasAlpha) {
+          gl.clearColor(0, 0, 0, 0);
+          gl.clear(gl.COLOR_BUFFER_BIT);
+        }
+        gl.useProgram(prog);
+        gl.uniform2f(uR, canvas.width, canvas.height);
+        gl.uniform1f(uT, t);
+        gl.uniform2f(uM, smooth[0], smooth[1]);
+        gl.uniform2f(uC, click[0], click[1]);
+        gl.uniform1f(uCT, clickT);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+        rafId = requestAnimationFrame(frame);
+      }
+      frame();
+
+      // Pause rendering when offscreen to save battery.
+      if (window.IntersectionObserver) {
+        new IntersectionObserver(function (entries) {
+          entries.forEach(function (entry) {
+            visible = entry.isIntersecting;
+            if (visible && rafId === null) frame();
+            if (!visible && video) video.pause();
+            else if (visible && video) {
+              var pl2 = video.play && video.play();
+              if (pl2 && pl2.catch) pl2.catch(function () {});
+            }
+          });
+        }, { rootMargin: '50px' }).observe(root);
+      }
+    }
+  })();
+</script>
+
+{% schema %}
+{
+  "name": "Interactive wallpaper",
+  "tag": "section",
+  "class": "section section--interactive-wallpaper-banner",
+  "disabled_on": {
+    "groups": ["header", "footer"]
+  },
+  "settings": [
+    {
+      "type": "header",
+      "content": "Background"
+    },
+    {
+      "type": "select",
+      "id": "wallpaper_variant",
+      "label": "Interactive background",
+      "default": "vapor",
+      "info": "Choose which interactive shader wallpaper to render. All react to cursor movement; click for a burst effect.",
+      "options": [
+        { "value": "nebula",        "label": "Nebula — flowing cosmic clouds" },
+        { "value": "horizon",       "label": "Horizon — synthwave perspective grid" },
+        { "value": "voronoi",       "label": "Voronoi — neon crystal cells" },
+        { "value": "synapse",       "label": "Synapse — neural plexus, chain-reaction firing" },
+        { "value": "noir",          "label": "Noir — cyberpunk plexus + RGB glitch shockwave" },
+        { "value": "bloom",         "label": "Bloom — bioluminescent fireflies + spark cascades" },
+        { "value": "constellation", "label": "Constellation — sparse stars + lightning bolt click" },
+        { "value": "vapor",         "label": "Vapor — cyberpunk constellation with chromatic bolts" },
+        { "value": "drive",         "label": "Drive — Vapor effects over background video" }
+      ]
+    },
+    {
+      "type": "url",
+      "id": "video_url",
+      "label": "Background video URL (Drive only)",
+      "info": "MP4 URL used when the Drive variant is selected. Defaults to a Shopify-hosted clip."
+    },
+    {
+      "type": "range",
+      "id": "section_height",
+      "label": "Section height",
+      "min": 40,
+      "max": 100,
+      "step": 5,
+      "default": 100,
+      "unit": "vh"
+    },
+    {
+      "type": "range",
+      "id": "image_overlay_opacity",
+      "label": "Overlay opacity",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "unit": "%",
+      "default": 0,
+      "info": "Darkens the background to improve text contrast."
+    },
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "checkbox",
+      "id": "extend_behind_header",
+      "label": "Extend behind site header",
+      "default": true,
+      "info": "Pulls the banner up so its background fills the area behind the header. The header becomes transparent over this section."
+    },
+    {
+      "type": "header",
+      "content": "Content"
+    },
+    {
+      "type": "select",
+      "id": "desktop_content_position",
+      "label": "Position",
+      "default": "middle",
+      "options": [
+        { "value": "top",    "label": "Top" },
+        { "value": "middle", "label": "Middle" },
+        { "value": "bottom", "label": "Bottom" }
+      ]
+    },
+    {
+      "type": "select",
+      "id": "desktop_content_alignment",
+      "label": "Alignment",
+      "default": "center",
+      "options": [
+        { "value": "left",   "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right",  "label": "Right" }
+      ]
+    },
+    {
+      "type": "checkbox",
+      "id": "show_text_box",
+      "label": "Show text box",
+      "default": false
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "Color scheme",
+      "default": "scheme-1"
+    },
+    {
+      "type": "header",
+      "content": "Mobile"
+    },
+    {
+      "type": "select",
+      "id": "mobile_content_alignment",
+      "label": "Mobile alignment",
+      "default": "center",
+      "options": [
+        { "value": "left",   "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right",  "label": "Right" }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "subheading",
+      "name": "Subtitle",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "text",
+          "id": "subheading",
+          "label": "Subtitle",
+          "default": "Subtitle"
+        }
+      ]
+    },
+    {
+      "type": "heading",
+      "name": "Title",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "inline_richtext",
+          "id": "heading",
+          "label": "Title",
+          "default": "Interactive wallpaper"
+        },
+        {
+          "type": "select",
+          "id": "heading_size",
+          "label": "Title size",
+          "default": "h1",
+          "options": [
+            { "value": "h2",   "label": "Small" },
+            { "value": "h1",   "label": "Medium" },
+            { "value": "h0",   "label": "Large" },
+            { "value": "hxl",  "label": "Extra large" },
+            { "value": "hxxl", "label": "Extra extra large" }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "name": "Description",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "richtext",
+          "id": "text",
+          "label": "Description",
+          "default": "<p>Move your cursor to interact. Click anywhere for a burst effect.</p>"
+        }
+      ]
+    },
+    {
+      "type": "buttons",
+      "name": "Buttons",
+      "limit": 1,
+      "settings": [
+        {
+          "type": "header",
+          "content": "Button 1"
+        },
+        {
+          "type": "text",
+          "id": "button_label_1",
+          "label": "Button label",
+          "default": "Shop now",
+          "info": "Leave blank to hide the button."
+        },
+        {
+          "type": "url",
+          "id": "button_link_1",
+          "label": "Button link"
+        },
+        {
+          "type": "checkbox",
+          "id": "button_style_secondary_1",
+          "label": "Use outline button style",
+          "default": false
+        },
+        {
+          "type": "header",
+          "content": "Button 2"
+        },
+        {
+          "type": "text",
+          "id": "button_label_2",
+          "label": "Button label",
+          "info": "Leave blank to hide the button."
+        },
+        {
+          "type": "url",
+          "id": "button_link_2",
+          "label": "Button link"
+        },
+        {
+          "type": "checkbox",
+          "id": "button_style_secondary_2",
+          "label": "Use outline button style",
+          "default": true
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Interactive wallpaper",
+      "blocks": [
+        { "type": "subheading" },
+        { "type": "heading" },
+        { "type": "text" },
+        { "type": "buttons" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/interactive-wallpaper-banner.liquid
+++ b/sections/interactive-wallpaper-banner.liquid
@@ -505,7 +505,7 @@
 
 {% schema %}
 {
-  "name": "Interactive wallpaper",
+  "name": "Interactive wallpaper banner",
   "tag": "section",
   "class": "section section--interactive-wallpaper-banner",
   "disabled_on": {
@@ -523,15 +523,15 @@
       "default": "vapor",
       "info": "Choose which interactive shader wallpaper to render. All react to cursor movement; click for a burst effect.",
       "options": [
-        { "value": "nebula",        "label": "Nebula — flowing cosmic clouds" },
-        { "value": "horizon",       "label": "Horizon — synthwave perspective grid" },
-        { "value": "voronoi",       "label": "Voronoi — neon crystal cells" },
-        { "value": "synapse",       "label": "Synapse — neural plexus, chain-reaction firing" },
-        { "value": "noir",          "label": "Noir — cyberpunk plexus + RGB glitch shockwave" },
-        { "value": "bloom",         "label": "Bloom — bioluminescent fireflies + spark cascades" },
-        { "value": "constellation", "label": "Constellation — sparse stars + lightning bolt click" },
-        { "value": "vapor",         "label": "Vapor — cyberpunk constellation with chromatic bolts" },
-        { "value": "drive",         "label": "Drive — Vapor effects over background video" }
+        { "value": "nebula",        "label": "Nebula - flowing cosmic clouds" },
+        { "value": "horizon",       "label": "Horizon - synthwave perspective grid" },
+        { "value": "voronoi",       "label": "Voronoi - neon crystal cells" },
+        { "value": "synapse",       "label": "Synapse - neural plexus with chain firing" },
+        { "value": "noir",          "label": "Noir - cyberpunk plexus + glitch shockwave" },
+        { "value": "bloom",         "label": "Bloom - bioluminescent fireflies + sparks" },
+        { "value": "constellation", "label": "Constellation - sparse stars + lightning click" },
+        { "value": "vapor",         "label": "Vapor - cyberpunk constellation, chromatic bolts" },
+        { "value": "drive",         "label": "Drive - Vapor effects over background video" }
       ]
     },
     {
@@ -739,7 +739,7 @@
   ],
   "presets": [
     {
-      "name": "Interactive wallpaper",
+      "name": "Interactive wallpaper banner",
       "blocks": [
         { "type": "subheading" },
         { "type": "heading" },

--- a/sections/interactive-wallpaper-banner.liquid
+++ b/sections/interactive-wallpaper-banner.liquid
@@ -160,7 +160,6 @@
   id="InteractiveWallpaperBanner-{{ section.id }}"
   class="interactive-wallpaper-banner color-{{ section.settings.color_scheme }} iwb iwb--pos-{{ section.settings.desktop_content_position }} iwb--align-{{ section.settings.desktop_content_alignment }} iwb--align-mobile-{{ section.settings.mobile_content_alignment }}{% unless section.settings.show_text_box %} iwb--no-box{% endunless %}{% if extend %} iwb--behind-header{% endif %}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--fade-in{% endif %}"
   data-variant="{{ variant }}"
-  {% if needs_video %}data-video-url="{{ video_url }}"{% endif %}
 >
   {%- if needs_video -%}
     <video
@@ -248,15 +247,16 @@
       var interaction = root.querySelector('.iwb__interaction');
       var video = root.querySelector('.iwb__video');
 
+      function fallback() {
+        root.style.background = 'linear-gradient(135deg,#0a0524,#1a0a3d,#0a0524)';
+      }
+
       var gl = canvas.getContext('webgl2', {
         antialias: false,
         alpha: !!variant.hasAlpha,
         premultipliedAlpha: false,
       });
-      if (!gl) {
-        root.style.background = 'linear-gradient(135deg,#0a0524,#1a0a3d,#0a0524)';
-        return;
-      }
+      if (!gl) { fallback(); return; }
 
       if (video) {
         var pl = video.play && video.play();
@@ -269,15 +269,21 @@
         gl.compileShader(s);
         if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
           console.error('[interactive-wallpaper-banner] shader compile:\n' + gl.getShaderInfoLog(s));
+          gl.deleteShader(s);
+          return null;
         }
         return s;
       }
+      var vsh = compile(gl.VERTEX_SHADER, L.VERT);
+      var fsh = compile(gl.FRAGMENT_SHADER, L.COMMON + variant.source);
+      if (!vsh || !fsh) { fallback(); return; }
       var prog = gl.createProgram();
-      gl.attachShader(prog, compile(gl.VERTEX_SHADER, L.VERT));
-      gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, L.COMMON + variant.source));
+      gl.attachShader(prog, vsh);
+      gl.attachShader(prog, fsh);
       gl.linkProgram(prog);
       if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
         console.error('[interactive-wallpaper-banner] link:\n' + gl.getProgramInfoLog(prog));
+        fallback();
         return;
       }
 
@@ -301,6 +307,15 @@
       var clickT = -100;
       var t0 = performance.now() / 1000;
 
+      // Track every listener / observer / RAF we register so we can dispose
+      // them when the Shopify theme editor unloads this section.
+      var listeners = [];
+      function on(target, event, handler, opts) {
+        target.addEventListener(event, handler, opts);
+        listeners.push({ t: target, e: event, h: handler, o: opts });
+      }
+      var observers = [];
+
       function resize() {
         var dpr = Math.min(window.devicePixelRatio || 1, 2);
         var w = canvas.clientWidth || root.clientWidth;
@@ -311,13 +326,13 @@
       }
       resize();
       if (window.ResizeObserver) {
-        new ResizeObserver(resize).observe(canvas);
+        var ro = new ResizeObserver(resize);
+        ro.observe(canvas);
+        observers.push(ro);
       } else {
-        window.addEventListener('resize', resize);
+        on(window, 'resize', resize);
       }
 
-      // Track mouse anywhere over the banner; clicks fire effects unless the
-      // pointer is over an interactive element (button/link).
       function setMouseFromEvent(e) {
         var r = canvas.getBoundingClientRect();
         mouse[0] = (e.clientX - r.left) / r.width;
@@ -329,29 +344,34 @@
         click[1] = 1 - (e.clientY - r.top) / r.height;
         clickT = performance.now() / 1000 - t0;
       }
+      function onMouseLeave() { mouse[0] = 0.5; mouse[1] = 0.5; }
+      function onTouchMove(e) { if (e.touches[0]) setMouseFromEvent(e.touches[0]); }
+      function onTouchStart(e) { if (e.touches[0]) setClickFromEvent(e.touches[0]); }
 
-      root.addEventListener('mousemove', setMouseFromEvent);
-      root.addEventListener('click', setClickFromEvent);
-      root.addEventListener('mouseleave', function () { mouse[0] = 0.5; mouse[1] = 0.5; });
-      root.addEventListener('touchmove', function (e) {
-        if (!e.touches[0]) return;
-        setMouseFromEvent(e.touches[0]);
-      }, { passive: true });
-      root.addEventListener('touchstart', function (e) {
-        if (!e.touches[0]) return;
-        setClickFromEvent(e.touches[0]);
-      }, { passive: true });
+      on(root, 'mousemove', setMouseFromEvent);
+      on(root, 'click', setClickFromEvent);
+      on(root, 'mouseleave', onMouseLeave);
+      on(root, 'touchmove', onTouchMove, { passive: true });
+      on(root, 'touchstart', onTouchStart, { passive: true });
 
       // Header extension — measure how far our section sits below the top of
       // the page (i.e. the cumulative header-group height) and expose it as
       // a CSS variable so the banner can pull itself up under the header.
       var behindHeader = root.classList.contains('iwb--behind-header');
+      var headerEls = [];
+      function refreshHeaderCache() {
+        var nodes = document.querySelectorAll('.shopify-section-group-header-group');
+        headerEls = [];
+        for (var i = 0; i < nodes.length; i++) {
+          if (!nodes[i].contains(root)) headerEls.push(nodes[i]);
+        }
+      }
+      refreshHeaderCache();
       function getHeaderHeight() {
         var total = 0;
-        document.querySelectorAll('.shopify-section-group-header-group').forEach(function (el) {
-          if (el.contains(root)) return;
-          total += el.getBoundingClientRect().height;
-        });
+        for (var i = 0; i < headerEls.length; i++) {
+          total += headerEls[i].getBoundingClientRect().height;
+        }
         return total;
       }
       function updateHeaderOffset() {
@@ -361,39 +381,45 @@
         }
         var h = getHeaderHeight();
         if (h === 0) {
-          // Initial render before header element is measured: estimate from
-          // the section's current top offset.
           var rect = root.getBoundingClientRect();
           h = rect.top + window.scrollY + parseFloat(getComputedStyle(root).marginTop || '0');
         }
         root.style.setProperty('--iwb-header-offset', h + 'px');
       }
+      function onWindowResize() {
+        refreshHeaderCache();
+        updateHeaderOffset();
+        if (syncHeaderTransparency) syncHeaderTransparency();
+      }
       updateHeaderOffset();
-      window.addEventListener('load', updateHeaderOffset);
-      window.addEventListener('resize', updateHeaderOffset);
+      on(window, 'load', updateHeaderOffset);
+      on(window, 'resize', onWindowResize);
       setTimeout(updateHeaderOffset, 50);
       setTimeout(updateHeaderOffset, 500);
 
-      // Toggle a body class while the wallpaper section overlaps the header
-      // strip, so the header background becomes transparent only when the
-      // wallpaper is actually behind it.
+      // Toggle a body class while *any* wallpaper section overlaps the header
+      // strip. Each instance writes its own overlap state to a data attribute
+      // so multiple banners on one page can coexist without fighting over
+      // body.iwb-header-transparent.
+      var syncHeaderTransparency = null;
       if (behindHeader) {
-        var transparent = false;
-        function syncHeaderTransparency() {
+        var rafThrottle = false;
+        function _sync() {
+          rafThrottle = false;
           var rect = root.getBoundingClientRect();
           var headerH = getHeaderHeight() || 80;
           var overlaps = rect.top < headerH && rect.bottom > 0;
-          if (overlaps && !transparent) {
-            document.body.classList.add('iwb-header-transparent');
-            transparent = true;
-          } else if (!overlaps && transparent) {
-            document.body.classList.remove('iwb-header-transparent');
-            transparent = false;
-          }
+          root.dataset.iwbOverlapsHeader = overlaps ? 'true' : 'false';
+          var anyOverlap = !!document.querySelector('[data-iwb-overlaps-header="true"]');
+          document.body.classList.toggle('iwb-header-transparent', anyOverlap);
         }
+        syncHeaderTransparency = function () {
+          if (rafThrottle) return;
+          rafThrottle = true;
+          requestAnimationFrame(_sync);
+        };
         syncHeaderTransparency();
-        window.addEventListener('scroll', syncHeaderTransparency, { passive: true });
-        window.addEventListener('resize', syncHeaderTransparency);
+        on(window, 'scroll', syncHeaderTransparency, { passive: true });
         setTimeout(syncHeaderTransparency, 100);
       }
 
@@ -419,9 +445,8 @@
       }
       frame();
 
-      // Pause rendering when offscreen to save battery.
       if (window.IntersectionObserver) {
-        new IntersectionObserver(function (entries) {
+        var io = new IntersectionObserver(function (entries) {
           entries.forEach(function (entry) {
             visible = entry.isIntersecting;
             if (visible && rafId === null) frame();
@@ -431,7 +456,36 @@
               if (pl2 && pl2.catch) pl2.catch(function () {});
             }
           });
-        }, { rootMargin: '50px' }).observe(root);
+        }, { rootMargin: '50px' });
+        io.observe(root);
+        observers.push(io);
+      }
+
+      // Theme-editor cleanup. Shopify fires shopify:section:unload before
+      // re-rendering a section after a setting change; without this hook the
+      // animation loop, listeners, and WebGL context all leak.
+      function cleanup() {
+        visible = false;
+        if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+        listeners.forEach(function (l) { l.t.removeEventListener(l.e, l.h, l.o); });
+        listeners.length = 0;
+        observers.forEach(function (o) { try { o.disconnect(); } catch (_) {} });
+        observers.length = 0;
+        delete root.dataset.iwbOverlapsHeader;
+        var anyOverlap = !!document.querySelector('[data-iwb-overlaps-header="true"]');
+        document.body.classList.toggle('iwb-header-transparent', anyOverlap);
+        try {
+          var loseExt = gl.getExtension('WEBGL_lose_context');
+          if (loseExt) loseExt.loseContext();
+        } catch (_) {}
+      }
+      if (typeof Shopify !== 'undefined' && Shopify.designMode) {
+        document.addEventListener('shopify:section:unload', function onUnload(e) {
+          if (e && e.detail && e.detail.sectionId === '{{ section.id }}') {
+            document.removeEventListener('shopify:section:unload', onUnload);
+            cleanup();
+          }
+        });
       }
     }
   })();

--- a/sections/interactive-wallpaper-banner.liquid
+++ b/sections/interactive-wallpaper-banner.liquid
@@ -150,7 +150,6 @@
     border-bottom-color: transparent !important;
   }
   body.iwb-header-transparent .section-header {
-    position: relative;
     z-index: 4;
   }
 </style>


### PR DESCRIPTION
## Summary

Adds a new **Interactive wallpaper** section to the theme that uses the nine
WebGL "synapse" wallpapers from the Claude Design handoff bundle. Same block
structure as the video banner (subtitle + title + description + buttons),
plus a section-level dropdown to pick which interactive background to render.

- **`assets/interactive-wallpaper-shaders.js`** — single library containing
  the common GLSL prefix plus all nine fragment-shader sources (Nebula,
  Horizon, Voronoi, Synapse, Noir, Bloom, Constellation, Vapor, Drive).
  Exposed on `window.OmniflexInteractiveWallpapers` so the section picks
  one by key at render time.
- **`sections/interactive-wallpaper-banner.liquid`** — the section itself:
  canvas + (Drive only) `<video>` background, content overlay with the
  same `heading` / `text` / `buttons` blocks as `video-banner` plus a new
  `subheading` block for the subtitle. Per-instance WebGL2 setup, cursor
  smoothing, click-time tracking, `ResizeObserver`-driven canvas sizing,
  and `IntersectionObserver` pause when offscreen.

### "Extend behind site header" mode

When the **Extend behind site header** checkbox is on (default), the section
measures the cumulative height of every `.shopify-section-group-header-group`
on the page, exposes it as a CSS custom property, and pulls the section up by
that amount with negative `margin-top`. The content area gets matching
`padding-top` so headings/buttons don't hide under the header.

The header is only made transparent **while** the wallpaper is overlapping it
— a `scroll` + `resize` listener toggles `body.iwb-header-transparent`,
which a scoped style block uses to override `.section-header`, the
`.header-wrapper.gradient` background image, and the bottom border. Once
you scroll past the banner, the header returns to normal styling.

### Background variants

The dropdown surfaces all nine variants with descriptive labels. The Drive
variant additionally accepts a custom MP4 URL (defaults to the
Shopify-hosted clip from the design bundle); its shader outputs a luminance-
based alpha so the video shows through wherever the neon network is dark.

## Test plan

- [ ] In the theme editor, open any page template → **Add section** →
  confirm **Interactive wallpaper** appears in the section picker.
- [ ] Add it to a page; verify the default Vapor variant renders and reacts
  to cursor motion / clicks.
- [ ] Toggle through each of the nine variants in the dropdown; verify each
  one compiles and renders distinctly.
- [ ] Pick **Drive**; verify the background video plays underneath the
  neon network and that swapping the **Background video URL** field
  replaces it.
- [ ] Toggle **Extend behind site header**: with it on, the wallpaper
  should reach the very top of the viewport and the header should be
  transparent over the section; scrolling past should restore the
  header's normal background.
- [ ] Try adjusting **Section height**, **Overlay opacity**, content
  **Position / Alignment**, **Show text box**, and the **Color scheme**
  swatch — confirm each affects the overlay as expected.
- [ ] Resize the window / DevTools to a phone width — wallpaper still
  fills, mobile alignment setting applies.

https://claude.ai/code/session_01NzBAFtKbaD5FUusUCXWCMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzBAFtKbaD5FUusUCXWCMD)_