### PR TITLE
Add scheme-aware neon glow option for outline and fill buttons

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -29,6 +29,11 @@
     "buttons_shadow_horizontal_offset": 0,
     "buttons_shadow_vertical_offset": 4,
     "buttons_shadow_blur": 5,
+    "neon_button_glow": true,
+    "neon_button_glow_fill": true,
+    "neon_button_glow_outline": true,
+    "neon_button_glow_blur": 14,
+    "neon_button_glow_intensity": 90,
     "variant_pills_border_thickness": 1,
     "variant_pills_border_opacity": 55,
     "variant_pills_radius": 40,
@@ -555,10 +560,6 @@
   },
   "platform_customizations": {
     "custom_css": [
-      "/* GLOBAL: Dynamic Neon Glow for Solid Buttons */.button:not(.button--outline) {border: none !important; box-shadow: 0 0 5px rgb(var(--color-button)), 0 0 15px rgb(var(--color-button)), 0 0 30px rgb(var(--color-button)) !important; transition: all 0.3s ease-in-out !important;}",
-      ".button:not(.button--outline):hover {box-shadow: 0 0 10px rgb(var(--color-button)), 0 0 25px rgb(var(--color-button)), 0 0 50px rgb(var(--color-button)) !important; transform: scale(1.02);}",
-      " /* GLOBAL: Dynamic Neon Glow for Outline Buttons */.button--outline {box-shadow: 0 0 5px rgb(var(--color-base-outline-button-labels)), 0 0 15px rgb(var(--color-base-outline-button-labels)), inset 0 0 5px rgb(var(--color-base-outline-button-labels)), inset 0 0 10px rgb(var(--color-base-outline-button-labels)) !important; text-shadow: 0 0 5px rgb(var(--color-base-outline-button-labels)) !important; transition: all 0.3s ease-in-out !important;}",
-      ".button--outline:hover {background-color: rgb(var(--color-base-outline-button-labels)) !important; color: rgb(var(--color-background)) !important; box-shadow: 0 0 10px rgb(var(--color-base-outline-button-labels)), 0 0 30px rgb(var(--color-base-outline-button-labels)), inset 0 0 10px rgb(var(--color-base-outline-button-labels)) !important; text-shadow: none !important;}",
       "button.timesact-button-cs {background-image: none !important;}",
       "div[id*=\"animated_divider\"] {z-index: 1000 !important;}"
     ]

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -311,6 +311,52 @@
         "unit": "px",
         "label": "t:settings_schema.global.settings.blur.label",
         "default": 0
+      },
+      {
+        "type": "header",
+        "content": "Neon glow"
+      },
+      {
+        "type": "paragraph",
+        "content": "Adds a neon glow around buttons using each color scheme's button colors, so the effect adapts to every scheme. Fill buttons glow with their fill color; outline buttons glow with their outline color."
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_button_glow",
+        "label": "Enable neon button glow",
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_button_glow_fill",
+        "label": "Glow on fill (solid) buttons",
+        "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "neon_button_glow_outline",
+        "label": "Glow on outline buttons",
+        "default": true
+      },
+      {
+        "type": "range",
+        "id": "neon_button_glow_blur",
+        "min": 0,
+        "max": 40,
+        "step": 2,
+        "unit": "px",
+        "label": "Glow size",
+        "default": 14
+      },
+      {
+        "type": "range",
+        "id": "neon_button_glow_intensity",
+        "min": 0,
+        "max": 150,
+        "step": 5,
+        "unit": "%",
+        "label": "Glow intensity",
+        "default": 90
       }
     ]
   },

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -260,12 +260,20 @@
     {%- comment -%}
       Neon button glow. Loaded after base.css so the glow wins on equal
       specificity, but kept to single-class selectors so Dawn's focus-visible
-      ring (a higher-specificity box-shadow) is preserved for keyboard users.
+      ring (.button:focus-visible, specificity 0,2,0) still outranks it and the
+      keyboard focus indicator is preserved.
 
       Fill buttons glow with each color scheme's button color (--color-button);
       outline buttons glow with the scheme's outline label color
-      (--color-secondary-button-text). Because both are per-scheme CSS
-      variables, the glow adapts to every color scheme automatically.
+      (--color-secondary-button-text). Both are per-scheme CSS variables, so the
+      glow adapts to every color scheme automatically.
+
+      In Dawn an outline button is `.button.button--secondary`, so the fill rule
+      (`.button`) also matches it. When the outline glow is disabled we clear the
+      glow on secondary/outline buttons so the two toggles stay isolated. The
+      effect is deliberately limited to box-shadow / text-shadow only - no
+      transform or transition override - so Dawn's native hover animations
+      (Theme settings > Animations) and transitions are left untouched.
     {%- endcomment -%}
     {%- if settings.neon_button_glow -%}
       {%- liquid
@@ -292,13 +300,11 @@
             0 0 {{ nbg_blur }}px rgba(var(--color-button), {{ nbg_a1 }}),
             0 0 {{ nbg_blur_mid }}px rgba(var(--color-button), {{ nbg_a2 }}),
             0 0 {{ nbg_blur_far }}px rgba(var(--color-button), {{ nbg_a3 }});
-          transition: box-shadow var(--duration-short) ease, transform var(--duration-short) ease;
         }
         .button:hover {
           box-shadow:
             0 0 {{ nbg_blur_h }}px rgba(var(--color-button), {{ nbg_a1_h }}),
             0 0 {{ nbg_blur_h_far }}px rgba(var(--color-button), {{ nbg_a3_h }});
-          transform: translateY(-1px);
         }
         {%- endif -%}
         {%- if settings.neon_button_glow_outline -%}
@@ -309,7 +315,6 @@
             0 0 {{ nbg_blur_mid }}px rgba(var(--color-secondary-button-text), {{ nbg_a2 }}),
             inset 0 0 {{ nbg_blur }}px rgba(var(--color-secondary-button-text), {{ nbg_inset }});
           text-shadow: 0 0 {{ nbg_blur_text }}px rgba(var(--color-secondary-button-text), {{ nbg_text }});
-          transition: box-shadow var(--duration-short) ease, transform var(--duration-short) ease, background-color var(--duration-short) ease, color var(--duration-short) ease;
         }
         .button--secondary:hover,
         .button--outline:hover {
@@ -317,7 +322,13 @@
             0 0 {{ nbg_blur_h }}px rgba(var(--color-secondary-button-text), {{ nbg_a1_h }}),
             0 0 {{ nbg_blur_h_far }}px rgba(var(--color-secondary-button-text), {{ nbg_a2_h }}),
             inset 0 0 {{ nbg_blur_h }}px rgba(var(--color-secondary-button-text), {{ nbg_inset }});
-          transform: translateY(-1px);
+        }
+        {%- elsif settings.neon_button_glow_fill -%}
+        .button--secondary,
+        .button--outline,
+        .button--secondary:hover,
+        .button--outline:hover {
+          box-shadow: none;
         }
         {%- endif -%}
       </style>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -256,6 +256,73 @@
     {% endstyle %}
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
+
+    {%- comment -%}
+      Neon button glow. Loaded after base.css so the glow wins on equal
+      specificity, but kept to single-class selectors so Dawn's focus-visible
+      ring (a higher-specificity box-shadow) is preserved for keyboard users.
+
+      Fill buttons glow with each color scheme's button color (--color-button);
+      outline buttons glow with the scheme's outline label color
+      (--color-secondary-button-text). Because both are per-scheme CSS
+      variables, the glow adapts to every color scheme automatically.
+    {%- endcomment -%}
+    {%- if settings.neon_button_glow -%}
+      {%- liquid
+        assign nbg_blur = settings.neon_button_glow_blur | default: 14
+        assign nbg_int = settings.neon_button_glow_intensity | default: 90
+        assign nbg_blur_mid = nbg_blur | times: 2
+        assign nbg_blur_far = nbg_blur | times: 3
+        assign nbg_blur_h = nbg_blur | times: 1.6 | round
+        assign nbg_blur_h_far = nbg_blur | times: 3.2 | round
+        assign nbg_blur_text = nbg_blur | divided_by: 2
+        assign nbg_a1 = nbg_int | times: 0.006 | at_most: 1.0
+        assign nbg_a2 = nbg_int | times: 0.0035 | at_most: 1.0
+        assign nbg_a3 = nbg_int | times: 0.002 | at_most: 1.0
+        assign nbg_inset = nbg_int | times: 0.003 | at_most: 1.0
+        assign nbg_text = nbg_int | times: 0.005 | at_most: 1.0
+        assign nbg_a1_h = nbg_int | times: 0.009 | at_most: 1.0
+        assign nbg_a2_h = nbg_int | times: 0.006 | at_most: 1.0
+        assign nbg_a3_h = nbg_int | times: 0.004 | at_most: 1.0
+      -%}
+      <style>
+        {%- if settings.neon_button_glow_fill -%}
+        .button {
+          box-shadow:
+            0 0 {{ nbg_blur }}px rgba(var(--color-button), {{ nbg_a1 }}),
+            0 0 {{ nbg_blur_mid }}px rgba(var(--color-button), {{ nbg_a2 }}),
+            0 0 {{ nbg_blur_far }}px rgba(var(--color-button), {{ nbg_a3 }});
+          transition: box-shadow var(--duration-short) ease, transform var(--duration-short) ease;
+        }
+        .button:hover {
+          box-shadow:
+            0 0 {{ nbg_blur_h }}px rgba(var(--color-button), {{ nbg_a1_h }}),
+            0 0 {{ nbg_blur_h_far }}px rgba(var(--color-button), {{ nbg_a3_h }});
+          transform: translateY(-1px);
+        }
+        {%- endif -%}
+        {%- if settings.neon_button_glow_outline -%}
+        .button--secondary,
+        .button--outline {
+          box-shadow:
+            0 0 {{ nbg_blur }}px rgba(var(--color-secondary-button-text), {{ nbg_a1 }}),
+            0 0 {{ nbg_blur_mid }}px rgba(var(--color-secondary-button-text), {{ nbg_a2 }}),
+            inset 0 0 {{ nbg_blur }}px rgba(var(--color-secondary-button-text), {{ nbg_inset }});
+          text-shadow: 0 0 {{ nbg_blur_text }}px rgba(var(--color-secondary-button-text), {{ nbg_text }});
+          transition: box-shadow var(--duration-short) ease, transform var(--duration-short) ease, background-color var(--duration-short) ease, color var(--duration-short) ease;
+        }
+        .button--secondary:hover,
+        .button--outline:hover {
+          box-shadow:
+            0 0 {{ nbg_blur_h }}px rgba(var(--color-secondary-button-text), {{ nbg_a1_h }}),
+            0 0 {{ nbg_blur_h_far }}px rgba(var(--color-secondary-button-text), {{ nbg_a2_h }}),
+            inset 0 0 {{ nbg_blur_h }}px rgba(var(--color-secondary-button-text), {{ nbg_inset }});
+          transform: translateY(-1px);
+        }
+        {%- endif -%}
+      </style>
+    {%- endif -%}
+
     <link rel="stylesheet" href="{{ 'component-cart-items.css' | asset_url }}" media="print" onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}


### PR DESCRIPTION
## What & why

The button neon glow only showed up on **fill** buttons, not on **outline** buttons — and only for some color schemes. This adds a proper, configurable theme option that makes the glow work on both button variants across **every** color scheme.

### Root cause

The glow was injected as raw CSS in `settings_data.json` → `custom_css`:

- The outline rule targeted a class that doesn't exist in Dawn (`.button--outline`, used only on the password page) and an **undefined** variable (`--color-base-outline-button-labels`). An undefined var inside `rgb()` makes the whole `box-shadow` invalid, so the browser dropped it → outline buttons never glowed.
- The fill rule `.button:not(.button--outline)` also matched the real outline buttons (`.button--secondary`), where Dawn remaps `--color-button` to the scheme **background** color → the glow rendered in the background color (invisible).

So: fill colors "looked good" (`--color-button` is valid), but the outline variants showed no glow.

## Changes

- **`config/settings_schema.json`** — New **"Neon glow"** group under *Theme settings → Buttons*:
  - Enable neon button glow (master toggle)
  - Glow on fill (solid) buttons
  - Glow on outline buttons
  - Glow size (blur, px)
  - Glow intensity (%)
- **`layout/theme.liquid`** — Settings-driven glow CSS, loaded **after** `base.css`:
  - Fill buttons glow with each scheme's `--color-button`.
  - Outline buttons (`.button--secondary`) glow with the scheme's outline label color `--color-secondary-button-text`.
  - Both are per-scheme CSS variables, so the glow adapts to every color scheme automatically.
  - Selectors stay at single-class specificity so Dawn's `:focus-visible` ring (higher specificity) is preserved for keyboard users.
- **`config/settings_data.json`** — Enabled the new settings in the active config and removed the four broken/conflicting glow rules from `custom_css` (kept the two unrelated rules). Their `!important` would otherwise override the new system.

## Notes / testing

- Defaults keep the look enabled out of the box (intensity 90%, blur 14px), reproducing the prior fill glow and adding the missing outline glow.
- The Interactive Wallpaper banner has its own ID-scoped button glow, which has higher specificity and is unaffected.
- Recommend a visual check in the theme editor across the `neon-*` and `scheme-*` color schemes, and toggling the fill/outline options.

https://claude.ai/code/session_012BdvgQxunURTahhqN9Xjqp

---
_Generated by [Claude Code](https://claude.ai/code/session_012BdvgQxunURTahhqN9Xjqp)_