### PR TITLE
Add Scrolling Text Divider section (animated marquee divider)

### DIFF
--- a/assets/section-scrolling-text-divider.css
+++ b/assets/section-scrolling-text-divider.css
@@ -1,0 +1,272 @@
+/* ==========================================================================
+   Scrolling Text Divider — animated marquee band of repeating text + symbol
+   Cyberpunk / vapourwave aesthetic. Most behaviour is driven by CSS custom
+   properties set per-section in the section's {% style %} block.
+   ========================================================================== */
+
+.cyber-divider {
+  --cd-height: 56px;
+  --cd-font-size: 24px;
+  --cd-letter-spacing: 0px;
+  --cd-gap: 24px;
+  --cd-sep-size: 24px;
+  --cd-sep-opacity: 1;
+  --cd-scroll-duration: 28s;
+  --cd-spin-duration: 6s;
+  --cd-effect: 5;
+  --cd-glow-color: #ff2d55;
+  --cd-glow-strength: 8px;
+  --cd-border-color: #ffffff;
+  --cd-bg-angle: 90deg;
+  --cd-bg-duration: 10s;
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: var(--cd-height);
+  overflow: hidden;
+  background: var(--cd-bg, #ff2d55);
+  color: var(--cd-text-color, #ffffff);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.cyber-divider--transparent {
+  background: transparent;
+}
+
+.cyber-divider--gradient {
+  background: linear-gradient(
+    var(--cd-bg-angle),
+    var(--cd-bg) 0%,
+    var(--cd-bg2) 50%,
+    var(--cd-bg) 100%
+  );
+  background-size: 200% 200%;
+  background-position: 0% 50%;
+}
+
+.cyber-divider--gradient.cyber-divider--animate-bg {
+  animation: cd-bg-shift var(--cd-bg-duration) ease-in-out infinite;
+}
+
+.cyber-divider--bordered {
+  border-top: 2px solid var(--cd-border-color);
+  border-bottom: 2px solid var(--cd-border-color);
+}
+
+/* Optional CRT scanline overlay */
+.cyber-divider--scanlines::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.18) 0,
+    rgba(0, 0, 0, 0.18) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: overlay;
+  z-index: 2;
+}
+
+/* --------------------------------------------------------------------------
+   Marquee track / groups / cells
+   -------------------------------------------------------------------------- */
+
+.cyber-divider__track {
+  display: flex;
+  flex: none;
+  width: max-content;
+  will-change: transform;
+}
+
+.cyber-divider:not(.cyber-divider--static) .cyber-divider__track {
+  animation: cd-scroll var(--cd-scroll-duration) linear infinite;
+}
+
+.cyber-divider--reverse .cyber-divider__track {
+  animation-direction: reverse;
+}
+
+.cyber-divider--pause-hover:hover .cyber-divider__track,
+.cyber-divider--pause-hover:hover .cyber-divider__cell,
+.cyber-divider--pause-hover:hover .cyber-divider__text {
+  animation-play-state: paused;
+}
+
+.cyber-divider__group {
+  display: flex;
+  flex: none;
+  align-items: center;
+}
+
+.cyber-divider__cell {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  gap: var(--cd-gap);
+  padding-right: var(--cd-gap);
+}
+
+.cyber-divider__text {
+  display: inline-block;
+  font-family: var(--cd-font-family, inherit);
+  font-weight: var(--cd-font-weight, 700);
+  font-style: var(--cd-font-style, normal);
+  font-size: var(--cd-font-size);
+  letter-spacing: var(--cd-letter-spacing);
+  text-transform: var(--cd-transform, none);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.cyber-divider--glow .cyber-divider__text {
+  text-shadow:
+    0 0 var(--cd-glow-strength) var(--cd-glow-color),
+    0 0 calc(var(--cd-glow-strength) * 2) var(--cd-glow-color);
+}
+
+.cyber-divider__sep {
+  flex: none;
+  line-height: 1;
+  opacity: var(--cd-sep-opacity);
+}
+
+.cyber-divider__sep--text {
+  font-size: var(--cd-sep-size);
+  color: var(--cd-sep-color, currentColor);
+}
+
+.cyber-divider__sep--img {
+  display: block;
+  height: var(--cd-sep-size);
+  width: auto;
+}
+
+.cyber-divider__sep--spin {
+  animation: cd-spin var(--cd-spin-duration) linear infinite;
+}
+
+/* --------------------------------------------------------------------------
+   Animation modes
+   -------------------------------------------------------------------------- */
+
+@keyframes cd-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+
+@keyframes cd-bg-shift {
+  0%   { background-position: 0% 50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@keyframes cd-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* Wave — each cell bobs vertically, staggered by --i for a travelling wave */
+.cyber-divider--wave .cyber-divider__cell {
+  animation: cd-wave 2.2s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * -0.18s);
+}
+
+@keyframes cd-wave {
+  0%, 100% { transform: translateY(calc(var(--cd-effect) * -1px)); }
+  50%      { transform: translateY(calc(var(--cd-effect) * 1px)); }
+}
+
+/* Pulse / breathe — staggered scale + opacity */
+.cyber-divider--pulse .cyber-divider__cell {
+  transform-origin: center;
+  animation: cd-pulse 1.8s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * -0.12s);
+}
+
+@keyframes cd-pulse {
+  0%, 100% { transform: scale(0.94); opacity: 0.6; }
+  50%      { transform: scale(1.12); opacity: 1; }
+}
+
+/* Neon flicker — staggered opacity flicker like a failing sign */
+.cyber-divider--flicker .cyber-divider__text {
+  animation: cd-flicker 3.2s steps(1, end) infinite;
+  animation-delay: calc(var(--i, 0) * -0.21s);
+}
+
+@keyframes cd-flicker {
+  0%, 18%, 22%, 54%, 58%, 80%, 100% { opacity: 1; }
+  20%, 56% { opacity: 0.3; }
+  21%, 57% { opacity: 0.75; }
+}
+
+/* Glitch — chromatic-aberration jitter via animated text-shadow + micro shift */
+.cyber-divider--glitch .cyber-divider__text {
+  animation: cd-glitch 2.4s steps(2, end) infinite;
+}
+
+@keyframes cd-glitch {
+  0%, 100% {
+    transform: translateX(0);
+    text-shadow:
+      calc(var(--cd-effect) * 0.4px) 0 #0ff,
+      calc(var(--cd-effect) * -0.4px) 0 #f0f;
+  }
+  20% {
+    transform: translateX(calc(var(--cd-effect) * 0.3px));
+    text-shadow:
+      calc(var(--cd-effect) * -0.6px) 0 #0ff,
+      calc(var(--cd-effect) * 0.6px) 0 #f0f;
+  }
+  40% {
+    transform: translateX(calc(var(--cd-effect) * -0.3px));
+    text-shadow:
+      calc(var(--cd-effect) * 0.6px) 0 #0ff,
+      calc(var(--cd-effect) * -0.6px) 0 #f0f;
+  }
+  60% {
+    transform: translateX(0);
+    text-shadow:
+      calc(var(--cd-effect) * -0.4px) 0 #0ff,
+      calc(var(--cd-effect) * 0.4px) 0 #f0f;
+  }
+  80% {
+    transform: translateX(calc(var(--cd-effect) * 0.2px));
+    text-shadow:
+      calc(var(--cd-effect) * 0.5px) 0 #0ff,
+      calc(var(--cd-effect) * -0.5px) 0 #f0f;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Accessibility — respect reduced-motion
+   -------------------------------------------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .cyber-divider .cyber-divider__track,
+  .cyber-divider .cyber-divider__cell,
+  .cyber-divider .cyber-divider__text,
+  .cyber-divider .cyber-divider__sep--spin,
+  .cyber-divider.cyber-divider--animate-bg {
+    animation: none !important;
+  }
+}
+
+/* Local fallback for the theme's visually-hidden helper */
+.cyber-divider .visually-hidden {
+  position: absolute !important;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  word-wrap: normal !important;
+}

--- a/sections/scrolling-text-divider.liquid
+++ b/sections/scrolling-text-divider.liquid
@@ -7,11 +7,19 @@
   assign mode = s.animation_mode
 
   comment
-    Italic checkbox overrides the picked font's style; otherwise inherit it.
+    Italic checkbox: load the font's real italic variant via font_modify so the
+    correct face is downloaded (no browser faux-italics). If the font has no
+    italic variant, font_modify returns nil and we fall back to CSS font-style.
   endcomment
   assign font_style = font.style
   if s.italic
-    assign font_style = 'italic'
+    assign italic_font = font | font_modify: 'style', 'italic'
+    if italic_font != blank
+      assign font = italic_font
+      assign font_style = italic_font.style
+    else
+      assign font_style = 'italic'
+    endif
   endif
 -%}
 
@@ -457,8 +465,7 @@
   ],
   "presets": [
     {
-      "name": "Scrolling Text Divider",
-      "category": "Decorative"
+      "name": "Scrolling Text Divider"
     }
   ]
 }

--- a/sections/scrolling-text-divider.liquid
+++ b/sections/scrolling-text-divider.liquid
@@ -1,0 +1,465 @@
+{{ 'section-scrolling-text-divider.css' | asset_url | stylesheet_tag }}
+
+{%- liquid
+  assign s = section.settings
+  assign font = s.font
+
+  assign mode = s.animation_mode
+
+  comment
+    Italic checkbox overrides the picked font's style; otherwise inherit it.
+  endcomment
+  assign font_style = font.style
+  if s.italic
+    assign font_style = 'italic'
+  endif
+-%}
+
+{%- style -%}
+  {{ font | font_face: font_display: 'swap' }}
+
+  #shopify-section-{{ section.id }} .cyber-divider--{{ section.id }} {
+    --cd-height: {{ s.divider_height }}px;
+    --cd-bg: {{ s.background_color }};
+    --cd-bg2: {{ s.gradient_color }};
+    --cd-bg-angle: {{ s.gradient_angle }}deg;
+    --cd-bg-duration: {{ s.background_speed }}s;
+    --cd-text-color: {{ s.text_color }};
+    --cd-font-family: {{ font.family }}, {{ font.fallback_families }};
+    --cd-font-weight: {{ font.weight }};
+    --cd-font-style: {{ font_style }};
+    --cd-font-size: {{ s.font_size }}px;
+    --cd-letter-spacing: {{ s.letter_spacing }}px;
+    --cd-transform: {{ s.text_transform }};
+    --cd-gap: {{ s.separator_gap }}px;
+    --cd-sep-size: {{ s.separator_size }}px;
+    --cd-sep-color: {{ s.separator_color }};
+    --cd-sep-opacity: {{ s.separator_opacity | divided_by: 100.0 }};
+    --cd-scroll-duration: {{ s.scroll_speed }}s;
+    --cd-spin-duration: {{ s.separator_spin_speed }}s;
+    --cd-effect: {{ s.effect_intensity }};
+    --cd-glow-color: {{ s.glow_color }};
+    --cd-glow-strength: {{ s.glow_strength }}px;
+    --cd-border-color: {{ s.border_color }};
+  }
+
+  @media screen and (max-width: 749px) {
+    #shopify-section-{{ section.id }} .cyber-divider--{{ section.id }} {
+      --cd-height: {{ s.divider_height_mobile }}px;
+      --cd-font-size: {{ s.font_size_mobile }}px;
+      --cd-sep-size: {{ s.separator_size_mobile }}px;
+    }
+  }
+{%- endstyle -%}
+
+<div
+  class="cyber-divider cyber-divider--{{ section.id }} cyber-divider--{{ mode }}
+    {%- if s.background_type == 'gradient' %} cyber-divider--gradient{% endif -%}
+    {%- if s.background_type == 'gradient' and s.animate_background %} cyber-divider--animate-bg{% endif -%}
+    {%- if s.background_type == 'transparent' %} cyber-divider--transparent{% endif -%}
+    {%- if mode == 'scroll-reverse' %} cyber-divider--reverse{% endif -%}
+    {%- if s.enable_glow %} cyber-divider--glow{% endif -%}
+    {%- if s.show_borders %} cyber-divider--bordered{% endif -%}
+    {%- if s.show_scanlines %} cyber-divider--scanlines{% endif -%}
+    {%- if s.pause_on_hover %} cyber-divider--pause-hover{% endif -%}"
+  role="presentation"
+  style="margin-top: {{ s.margin_top }}px; margin-bottom: {{ s.margin_bottom }}px;"
+>
+  {%- if s.text != blank -%}
+    <span class="visually-hidden">{{ s.text }}</span>
+  {%- endif -%}
+
+  <div class="cyber-divider__track" aria-hidden="true">
+    {%- comment -%} Two identical groups so the -50% scroll loops seamlessly {%- endcomment -%}
+    {%- for group in (1..2) -%}
+      <div class="cyber-divider__group">
+        {%- for i in (1..s.repeat_count) -%}
+          <span class="cyber-divider__cell" style="--i: {{ forloop.index0 }};">
+            <span class="cyber-divider__text">{{ s.text }}</span>
+            {%- if s.separator_image != blank -%}
+              <img
+                class="cyber-divider__sep cyber-divider__sep--img{% if s.separator_spin %} cyber-divider__sep--spin{% endif %}"
+                src="{{ s.separator_image | image_url: width: 240 }}"
+                alt=""
+                role="presentation"
+                loading="lazy"
+                width="{{ s.separator_image.width }}"
+                height="{{ s.separator_image.height }}"
+              >
+            {%- elsif s.separator_text != blank -%}
+              <span class="cyber-divider__sep cyber-divider__sep--text{% if s.separator_spin %} cyber-divider__sep--spin{% endif %}">{{ s.separator_text }}</span>
+            {%- endif -%}
+          </span>
+        {%- endfor -%}
+      </div>
+    {%- endfor -%}
+  </div>
+</div>
+
+{% schema %}
+{
+  "name": "Scrolling Text Divider",
+  "tag": "section",
+  "class": "section section--scrolling-text-divider",
+  "settings": [
+    {
+      "type": "header",
+      "content": "Layout"
+    },
+    {
+      "type": "range",
+      "id": "divider_height",
+      "label": "Height",
+      "min": 20,
+      "max": 200,
+      "step": 2,
+      "unit": "px",
+      "default": 56
+    },
+    {
+      "type": "range",
+      "id": "divider_height_mobile",
+      "label": "Height (mobile)",
+      "min": 16,
+      "max": 160,
+      "step": 2,
+      "unit": "px",
+      "default": 44
+    },
+    {
+      "type": "header",
+      "content": "Background"
+    },
+    {
+      "type": "select",
+      "id": "background_type",
+      "label": "Background type",
+      "options": [
+        { "value": "solid", "label": "Solid color" },
+        { "value": "gradient", "label": "Gradient" },
+        { "value": "transparent", "label": "Transparent" }
+      ],
+      "default": "solid"
+    },
+    {
+      "type": "color",
+      "id": "background_color",
+      "label": "Background color",
+      "default": "#ff2d55"
+    },
+    {
+      "type": "color",
+      "id": "gradient_color",
+      "label": "Gradient second color",
+      "info": "Used when background type is Gradient.",
+      "default": "#7b2ff7"
+    },
+    {
+      "type": "range",
+      "id": "gradient_angle",
+      "label": "Gradient angle",
+      "min": 0,
+      "max": 360,
+      "step": 5,
+      "unit": "deg",
+      "default": 90
+    },
+    {
+      "type": "checkbox",
+      "id": "animate_background",
+      "label": "Animate gradient",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "background_speed",
+      "label": "Gradient animation duration",
+      "min": 2,
+      "max": 30,
+      "step": 1,
+      "unit": "s",
+      "default": 10
+    },
+    {
+      "type": "header",
+      "content": "Text"
+    },
+    {
+      "type": "text",
+      "id": "text",
+      "label": "Text",
+      "default": "WELCOME"
+    },
+    {
+      "type": "range",
+      "id": "repeat_count",
+      "label": "Repeats per loop",
+      "info": "How many times the text appears before the loop restarts. Increase if you see a gap on wide screens.",
+      "min": 2,
+      "max": 24,
+      "step": 1,
+      "default": 10
+    },
+    {
+      "type": "font_picker",
+      "id": "font",
+      "label": "Font",
+      "default": "assistant_n7"
+    },
+    {
+      "type": "range",
+      "id": "font_size",
+      "label": "Font size",
+      "min": 8,
+      "max": 120,
+      "step": 1,
+      "unit": "px",
+      "default": 24
+    },
+    {
+      "type": "range",
+      "id": "font_size_mobile",
+      "label": "Font size (mobile)",
+      "min": 8,
+      "max": 90,
+      "step": 1,
+      "unit": "px",
+      "default": 18
+    },
+    {
+      "type": "range",
+      "id": "letter_spacing",
+      "label": "Letter spacing",
+      "min": -2,
+      "max": 16,
+      "step": 0.5,
+      "unit": "px",
+      "default": 2
+    },
+    {
+      "type": "select",
+      "id": "text_transform",
+      "label": "Text case",
+      "options": [
+        { "value": "none", "label": "As typed" },
+        { "value": "uppercase", "label": "UPPERCASE" },
+        { "value": "lowercase", "label": "lowercase" },
+        { "value": "capitalize", "label": "Capitalize" }
+      ],
+      "default": "uppercase"
+    },
+    {
+      "type": "checkbox",
+      "id": "italic",
+      "label": "Italic",
+      "default": false
+    },
+    {
+      "type": "color",
+      "id": "text_color",
+      "label": "Text color",
+      "default": "#ffffff"
+    },
+    {
+      "type": "header",
+      "content": "Separator symbol"
+    },
+    {
+      "type": "text",
+      "id": "separator_text",
+      "label": "Symbol",
+      "info": "Used when no image is set. Try ✦ ✱ + // ◆ ▰ ⬡ ★",
+      "default": "✦"
+    },
+    {
+      "type": "image_picker",
+      "id": "separator_image",
+      "label": "Symbol image",
+      "info": "Optional. Overrides the text symbol. Use a transparent PNG/SVG."
+    },
+    {
+      "type": "range",
+      "id": "separator_size",
+      "label": "Symbol size",
+      "min": 6,
+      "max": 120,
+      "step": 1,
+      "unit": "px",
+      "default": 22
+    },
+    {
+      "type": "range",
+      "id": "separator_size_mobile",
+      "label": "Symbol size (mobile)",
+      "min": 6,
+      "max": 90,
+      "step": 1,
+      "unit": "px",
+      "default": 16
+    },
+    {
+      "type": "color",
+      "id": "separator_color",
+      "label": "Symbol color",
+      "info": "Applies to the text symbol only.",
+      "default": "#ffffff"
+    },
+    {
+      "type": "range",
+      "id": "separator_opacity",
+      "label": "Symbol opacity",
+      "min": 0,
+      "max": 100,
+      "step": 5,
+      "unit": "%",
+      "default": 100
+    },
+    {
+      "type": "range",
+      "id": "separator_gap",
+      "label": "Spacing around symbol",
+      "min": 0,
+      "max": 80,
+      "step": 1,
+      "unit": "px",
+      "default": 24
+    },
+    {
+      "type": "checkbox",
+      "id": "separator_spin",
+      "label": "Spin symbol",
+      "default": false
+    },
+    {
+      "type": "range",
+      "id": "separator_spin_speed",
+      "label": "Spin duration",
+      "min": 1,
+      "max": 20,
+      "step": 0.5,
+      "unit": "s",
+      "default": 6
+    },
+    {
+      "type": "header",
+      "content": "Animation"
+    },
+    {
+      "type": "select",
+      "id": "animation_mode",
+      "label": "Text animation",
+      "options": [
+        { "value": "scroll", "label": "Scroll left" },
+        { "value": "scroll-reverse", "label": "Scroll right" },
+        { "value": "glitch", "label": "Glitch (scroll + RGB split)" },
+        { "value": "flicker", "label": "Neon flicker (scroll)" },
+        { "value": "wave", "label": "Wave (scroll + bob)" },
+        { "value": "pulse", "label": "Pulse (scroll + breathe)" },
+        { "value": "static", "label": "Static (no scroll)" }
+      ],
+      "default": "scroll"
+    },
+    {
+      "type": "range",
+      "id": "scroll_speed",
+      "label": "Scroll loop duration",
+      "info": "Lower is faster. Ignored in Static mode.",
+      "min": 4,
+      "max": 120,
+      "step": 1,
+      "unit": "s",
+      "default": 28
+    },
+    {
+      "type": "range",
+      "id": "effect_intensity",
+      "label": "Effect intensity",
+      "info": "Strength of Glitch, Wave and Pulse effects.",
+      "min": 1,
+      "max": 10,
+      "step": 1,
+      "default": 5
+    },
+    {
+      "type": "checkbox",
+      "id": "pause_on_hover",
+      "label": "Pause on hover",
+      "default": true
+    },
+    {
+      "type": "header",
+      "content": "Glow & borders"
+    },
+    {
+      "type": "checkbox",
+      "id": "enable_glow",
+      "label": "Neon text glow",
+      "default": false
+    },
+    {
+      "type": "color",
+      "id": "glow_color",
+      "label": "Glow color",
+      "default": "#ff2d55"
+    },
+    {
+      "type": "range",
+      "id": "glow_strength",
+      "label": "Glow strength",
+      "min": 0,
+      "max": 30,
+      "step": 1,
+      "unit": "px",
+      "default": 8
+    },
+    {
+      "type": "checkbox",
+      "id": "show_borders",
+      "label": "Top & bottom borders",
+      "default": false
+    },
+    {
+      "type": "color",
+      "id": "border_color",
+      "label": "Border color",
+      "default": "#ffffff"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_scanlines",
+      "label": "CRT scanlines overlay",
+      "default": false
+    },
+    {
+      "type": "header",
+      "content": "Section spacing"
+    },
+    {
+      "type": "range",
+      "id": "margin_top",
+      "label": "Top margin",
+      "min": 0,
+      "max": 100,
+      "step": 2,
+      "unit": "px",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "margin_bottom",
+      "label": "Bottom margin",
+      "min": 0,
+      "max": 100,
+      "step": 2,
+      "unit": "px",
+      "default": 0
+    }
+  ],
+  "presets": [
+    {
+      "name": "Scrolling Text Divider",
+      "category": "Decorative"
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary

Adds a new, reusable theme section — **Scrolling Text Divider** — that renders a full-width band of repeating text separated by a symbol, like the pink **“WELCOME ✦ WELCOME ✦ …”** divider in the reference design. It's available in the theme editor under **Add section → Decorative**.

This is a distinct element from the existing `animated-divider.liquid` (which is a thin line / gradient / image strip). Nothing existing was changed.

## What the merchant can manage

- **Layout** — height (desktop + mobile), top/bottom section margins
- **Background** — solid color, gradient (two colors + angle + optional animation), or transparent
- **Text** — content, font, size (desktop + mobile), letter spacing, case (UPPER/lower/Capitalize/as-typed), italic, color, and “repeats per loop” to avoid gaps on wide screens
- **Separator symbol** — a text glyph (e.g. `✦ ✱ + // ◆ ★`) **or** an uploaded image (transparent PNG/SVG), with size (desktop + mobile), color, opacity, surrounding spacing, and optional spin
- **Animation** — seven modes fitting the cyberpunk/vapourwave theme:
  - **Scroll left** (default), **Scroll right**
  - **Glitch** (scroll + RGB chromatic split)
  - **Neon flicker**, **Wave** (bob), **Pulse** (breathe), **Static**
  - plus **effect intensity**, **scroll loop duration**, and **pause-on-hover**
- **Glow & borders** — neon text glow (color + strength), top/bottom borders, and a CRT scanline overlay

## Implementation notes

- Files: `sections/scrolling-text-divider.liquid` + `assets/section-scrolling-text-divider.css`
- Seamless loop via a two-identical-group marquee track translated `-50%`
- All effects are pure CSS driven by per-section custom properties (no JS dependency)
- Honors `prefers-reduced-motion` (animations disabled)
- Decorative text is `aria-hidden`; a single `visually-hidden` copy is exposed to screen readers

## Preview

A standalone HTML preview demonstrating all seven modes (using the section's exact CSS) was shared in the session for visual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFUHBHWSDBDdPLuxkFukFk)_