### PR TITLE
Fix Scrolling Text Divider not appearing in section picker

### DIFF
--- a/sections/scrolling-text-divider.liquid
+++ b/sections/scrolling-text-divider.liquid
@@ -220,7 +220,7 @@
       "label": "Font size",
       "min": 8,
       "max": 120,
-      "step": 1,
+      "step": 2,
       "unit": "px",
       "default": 24
     },
@@ -291,7 +291,7 @@
       "label": "Symbol size",
       "min": 6,
       "max": 120,
-      "step": 1,
+      "step": 2,
       "unit": "px",
       "default": 22
     },
@@ -374,7 +374,7 @@
       "info": "Lower is faster. Ignored in Static mode.",
       "min": 4,
       "max": 120,
-      "step": 1,
+      "step": 2,
       "unit": "s",
       "default": 28
     },


### PR DESCRIPTION
## Summary

Fixes the **Scrolling Text Divider** section not showing up in the theme editor's "Add section" picker.

## Root cause

Three `range` settings exceeded Shopify's hard limit of **101 steps** for a slider (`(max − min) / step` must be ≤ 101). When a section's schema contains an invalid range, Shopify rejects the entire section, so it never appears in the editor:

| Setting | Before | Steps |
|---|---|---|
| `font_size` | 8–120, step 1 | 112 ✗ |
| `separator_size` | 6–120, step 1 | 114 ✗ |
| `scroll_speed` | 4–120, step 1 | 116 ✗ |

## Fix

Bump `step` from 1 → 2 on those three settings. The min/max range is unchanged, and the defaults (24 / 22 / 28) are even so they remain valid stops. New step counts: 56 / 57 / 58 — all well under the limit. All other ranges were already valid.

After this merges and the GitHub-connected theme syncs, **Scrolling Text Divider** will appear under **Add section → Decorative**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFUHBHWSDBDdPLuxkFukFk)_